### PR TITLE
Add CodeCov Badge to ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
 
+[![codecov](https://codecov.io/gh/AY2425S1-CS2103-F12-1/tp/graph/badge.svg?token=4P6LHV4HJ0)](https://codecov.io/gh/AY2425S1-CS2103-F12-1/tp)
+
 ![Ui](docs/images/Ui.png)
 
 * This is **a sample project for Software Engineering (SE) students**.<br>


### PR DESCRIPTION
It's a hassle to keep going to CodeCov to check on the coverage level of the project.

This makes the merge process longer than needed as the developer has to continuously do a manual check on codecov for the code coverage percent which makes them less efficient.

Let's automatically give visual feedback by adding in the codecov badge into the readme.

This makes merge process more efficient.