### PR TITLE
Add deleteInsurance command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteInsuranceCommand.java
@@ -8,12 +8,12 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 /**
- * Adds an InsurancePlan to an existing person in the address book.
+ * Removes an InsurancePlan from an existing person in the address book.
  */
-public class AddInsuranceCommand extends Command {
-    public static final String COMMAND_WORD = "addInsurance";
+public class DeleteInsuranceCommand extends Command {
+    public static final String COMMAND_WORD = "deleteInsurance";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds an insurance plan to the client identified "
+            + ": Deletes an insurance plan from a client identified "
             + "by their client id. \n"
             + "Parameters: INDEX (must be a positive integer) "
             + ", INSURANCE_PLAN_ID (must be a valid ID) \n"
@@ -26,10 +26,10 @@ public class AddInsuranceCommand extends Command {
     private final int insuranceID;
 
     /**
-     * @param index of the person in the filtered person list to edit the remark
+     * @param index of the person in the filtered person list remove the insurance plan from
      * @param insuranceID of the person to be updated to
      */
-    public AddInsuranceCommand(Index index, int insuranceID) {
+    public DeleteInsuranceCommand(Index index, int insuranceID) {
         requireAllNonNull(index, insuranceID);
 
         this.index = index;
@@ -49,7 +49,7 @@ public class AddInsuranceCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof AddInsuranceCommand e)) {
+        if (!(other instanceof DeleteInsuranceCommand e)) {
             return false;
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,12 +13,12 @@ import seedu.address.logic.commands.AddInsuranceCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteInsuranceCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.DeleteInsuranceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.DeleteInsuranceCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -80,6 +81,10 @@ public class AddressBookParser {
 
         case AddInsuranceCommand.COMMAND_WORD:
             return new AddInsuranceCommandParser().parse(arguments);
+
+        case DeleteInsuranceCommand.COMMAND_WORD:
+            return new DeleteInsuranceCommandParser().parse(arguments);
+
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/DeleteInsuranceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteInsuranceCommandParser.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE_ID;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.DeleteInsuranceCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and adds {@code DeleteInsurance} object
+ */
+public class DeleteInsuranceCommandParser implements Parser<DeleteInsuranceCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code RemarkCommand}
+     * and returns a {@code AddInsuranceCommand} object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteInsuranceCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INSURANCE_ID);
+        Index index;
+        int insuranceId;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            if (argMultimap.getValue(PREFIX_INSURANCE_ID).isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        DeleteInsuranceCommand.MESSAGE_USAGE));
+            }
+            insuranceId = ParserUtil.parseInsurancePlan(argMultimap.getValue(PREFIX_INSURANCE_ID).get());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteInsuranceCommand.MESSAGE_USAGE),
+                    ive);
+        }
+        return new DeleteInsuranceCommand(index, insuranceId);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteInsuranceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteInsuranceCommandParser.java
@@ -33,8 +33,8 @@ public class DeleteInsuranceCommandParser implements Parser<DeleteInsuranceComma
             }
             insuranceId = ParserUtil.parseInsurancePlan(argMultimap.getValue(PREFIX_INSURANCE_ID).get());
         } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteInsuranceCommand.MESSAGE_USAGE),
-                    ive);
+            throw new ParseException(String.format(
+                    MESSAGE_INVALID_COMMAND_FORMAT, DeleteInsuranceCommand.MESSAGE_USAGE), ive);
         }
         return new DeleteInsuranceCommand(index, insuranceId);
     }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddInsuranceCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteInsuranceCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
@@ -91,12 +92,6 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-                -> parser.parseCommand(""));
-    }
-
-    @Test
     public void parseCommand_addInsuranceCommand() throws Exception {
         String userInput = AddInsuranceCommand.COMMAND_WORD
                 + " "
@@ -104,9 +99,26 @@ public class AddressBookParserTest {
                 + " "
                 + PREFIX_INSURANCE_ID
                 + " 0 ";
-        System.out.println(userInput);
         AddInsuranceCommand command = (AddInsuranceCommand) parser.parseCommand(userInput);
         assertEquals(new AddInsuranceCommand(INDEX_FIRST_PERSON, 0), command);
+    }
+
+    @Test
+    public void parseCommand_deleteInsuranceCommand() throws Exception {
+        String userInput = DeleteInsuranceCommand.COMMAND_WORD
+                + " "
+                + INDEX_FIRST_PERSON.getOneBased()
+                + " "
+                + PREFIX_INSURANCE_ID
+                + " 0 ";
+        DeleteInsuranceCommand command = (DeleteInsuranceCommand) parser.parseCommand(userInput);
+        assertEquals(new DeleteInsuranceCommand(INDEX_FIRST_PERSON, 0), command);
+    }
+
+    @Test
+    public void parseCommand_unrecognisedInput_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+                -> parser.parseCommand(""));
     }
 
     @Test


### PR DESCRIPTION
I have implemented the deleteInsurance command in a (very) similar fashion to the add insurance command. As the insurance object has not been fully implemented into the `Person`, I have likewise not added that feature in this PR but will do so later

**Note to reviewer** : as much of the code was copied from the addInsurance side, please help me double check that all names / variables have been changed correctly and no trails of addInsurance are still there. Also help me check that the right tests are implemented for this feature.

Thanks!