### PR TITLE
Fix long term storage with insurance plans

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE_ID;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -63,6 +64,13 @@ public class AddInsuranceCommand extends Command {
             personToEditInsurancePlansManager.checkIfPlanNotOwned(planToBeAdded);
 
             personToEditInsurancePlansManager.addPlan(planToBeAdded);
+
+            Person editedPerson = new Person(
+                    personToEdit.getName(), personToEdit.getPhone(), personToEdit.getEmail(),
+                    personToEdit.getAddress(), personToEditInsurancePlansManager, personToEdit.getTags());
+
+            model.setPerson(personToEdit, editedPerson);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
             return new CommandResult(String.format(MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
                     personToEditInsurancePlansManager, Messages.format(personToEdit)));

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -118,6 +118,7 @@ public class Person {
                 .add("phone", phone)
                 .add("email", email)
                 .add("address", address)
+                .add("insurancePlans", insurancePlansManager.toString())
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -15,6 +15,8 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.insurance.InsurancePlan;
+import seedu.address.model.person.insurance.InsurancePlanFactory;
 import seedu.address.model.person.insurance.InsurancePlansManager;
 import seedu.address.model.tag.Tag;
 
@@ -74,6 +76,16 @@ class JsonAdaptedPerson {
             personTags.add(tag.toModelType());
         }
 
+        final InsurancePlansManager insurancePlansManager = new InsurancePlansManager();
+        List<String> listOfPlansOwned = List.of(insurancePlans.split(","));
+
+        if (!listOfPlansOwned.get(0).equals("None")) {
+            for (String insurancePlanString : listOfPlansOwned) {
+                InsurancePlan insurancePlan = InsurancePlanFactory.createInsurancePlan(insurancePlanString);
+                insurancePlansManager.addPlan(insurancePlan);
+            }
+        }
+
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
         }
@@ -110,10 +122,9 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     InsurancePlansManager.class.getSimpleName()));
         }
-        final InsurancePlansManager modelInsurancePlansManager = new InsurancePlansManager();
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelInsurancePlansManager, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, insurancePlansManager, modelTags);
     }
 
 }


### PR DESCRIPTION
On startup, the client data was not loading the insurance plans correctly from JSON saved data. As such it was possible to add plans that a client already owns after closing and restarting the app.

This makes the app's usefulness for the user a lot worse as they have to keep the app open all the time.

Let's fix this behaviour so the app can be loaded properly from storage.

This will make the app more useful to the user even if they closed the app or the app crashes halfway.

fixes #51 