### PR TITLE
Modify add and delete insurance commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
@@ -73,7 +73,7 @@ public class AddInsuranceCommand extends Command {
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
             return new CommandResult(String.format(MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
-                    personToEditInsurancePlansManager, Messages.format(personToEdit)));
+                    planToBeAdded, Messages.format(personWithAddedInsurancePlan)));
         } catch (ParseException e) {
             throw new CommandException(
                     String.format(e.getMessage(), insuranceID, Messages.format(personToEdit)));

--- a/src/main/java/seedu/address/logic/commands/DeleteInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteInsuranceCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE_ID;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -65,8 +66,13 @@ public class DeleteInsuranceCommand extends Command {
 
             personToEditInsurancePlansManager.deletePlan(planToBeDeleted);
 
+            Person personWithDeletedInsurancePlan = lastShownList.get(index.getZeroBased());
+
+            model.setPerson(personToEdit, personWithDeletedInsurancePlan);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
             return new CommandResult(String.format(MESSAGE_DELETE_INSURANCE_PLAN_SUCCESS,
-                    personToEditInsurancePlansManager, Messages.format(personToEdit)));
+                    planToBeDeleted, Messages.format(personWithDeletedInsurancePlan)));
         } catch (ParseException e) {
             throw new CommandException(
                     String.format(e.getMessage(), insuranceID, Messages.format(personToEdit)));


### PR DESCRIPTION
The feedback provided by the execution of these commands is not helpful. Delete was also not being saved properly due to a fault in the execute step.

Let's fix these bugs and make the feedback message clearer to the user so they will know what happened more clearly.