### PR TITLE
Fixed badge links in ReadMe.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/AY2425S1-CS2103-F12-1/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2425S1-CS2103-F12-1/tp/actions/)
 
 [![codecov](https://codecov.io/gh/AY2425S1-CS2103-F12-1/tp/graph/badge.svg?token=4P6LHV4HJ0)](https://codecov.io/gh/AY2425S1-CS2103-F12-1/tp)
 


### PR DESCRIPTION
The links in ReadMe.md is not linked properly.

Let's fix the links so the badges show the CI link more accurately.