### PR TITLE
Add tests for InsurancePlansManager.java

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
@@ -59,16 +59,13 @@ public class AddInsuranceCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
 
         try {
-            InsurancePlansManager personToEditInsurancePlansManager = personToEdit.getInsurancePlansManager();
-
             InsurancePlan planToBeAdded = InsurancePlanFactory.createInsurancePlan(insuranceID);
 
+            InsurancePlansManager personToEditInsurancePlansManager = personToEdit.getInsurancePlansManager();
             personToEditInsurancePlansManager.checkIfPlanNotOwned(planToBeAdded);
-
             personToEditInsurancePlansManager.addPlan(planToBeAdded);
 
             Person personWithAddedInsurancePlan = lastShownList.get(index.getZeroBased());
-
             model.setPerson(personToEdit, personWithAddedInsurancePlan);
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 

--- a/src/main/java/seedu/address/logic/commands/DeleteInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteInsuranceCommand.java
@@ -58,12 +58,10 @@ public class DeleteInsuranceCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
 
         try {
-            InsurancePlansManager personToEditInsurancePlansManager = personToEdit.getInsurancePlansManager();
-
             InsurancePlan planToBeDeleted = InsurancePlanFactory.createInsurancePlan(insuranceID);
 
+            InsurancePlansManager personToEditInsurancePlansManager = personToEdit.getInsurancePlansManager();
             personToEditInsurancePlansManager.checkIfPlanOwned(planToBeDeleted);
-
             personToEditInsurancePlansManager.deletePlan(planToBeDeleted);
 
             Person personWithDeletedInsurancePlan = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlanFactory.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlanFactory.java
@@ -7,7 +7,9 @@ import seedu.address.logic.parser.exceptions.ParseException;
  */
 public class InsurancePlanFactory {
 
-    /** Error message when a insuranceId passed in is invalid. */
+    /**
+     * Error message when a insuranceId or name passed in is invalid.
+     */
     public static final String INVALID_PLAN_ID_MESSAGE = "This Insurance Plan ID is invalid!";
     public static final String INVALID_PLAN_NAME_MESSAGE = "This Insurance Plan Name is invalid!";
 
@@ -44,5 +46,4 @@ public class InsurancePlanFactory {
             throw new ParseException(INVALID_PLAN_NAME_MESSAGE);
         }
     }
-
 }

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
@@ -95,6 +95,9 @@ public class InsurancePlansManager {
      * @throws ParseException if the plan is owned by the client.
      */
     public void checkIfPlanNotOwned(InsurancePlan plan) throws ParseException {
+        if (insurancePlans.isEmpty()) {
+            return;
+        }
         for (InsurancePlan p : insurancePlans) {
             if (p.equals(plan)) {
                 throw new ParseException(DUPLICATE_PLAN_DETECTED_MESSAGE);

--- a/src/test/java/seedu/address/model/person/insurance/InsurancePlanFactoryTest.java
+++ b/src/test/java/seedu/address/model/person/insurance/InsurancePlanFactoryTest.java
@@ -1,0 +1,72 @@
+package seedu.address.model.person.insurance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+class InsurancePlanFactoryTest {
+
+    @Test
+    void createInsurancePlanById_success() {
+        try {
+            InsurancePlan insurancePlan = InsurancePlanFactory.createInsurancePlan(0);
+            BasicPlan basicPlan = new BasicPlan();
+            assertEquals(insurancePlan, basicPlan);
+        } catch (ParseException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void createInsurancePlanById_invalidId() {
+        try {
+            InsurancePlan insurancePlan = InsurancePlanFactory.createInsurancePlan(-1);
+            fail();
+        } catch (ParseException e) {
+            assertEquals(e.getMessage(), InsurancePlanFactory.INVALID_PLAN_ID_MESSAGE);
+        }
+    }
+
+    @Test
+    void createInsurancePlanByString_success() {
+        try {
+            InsurancePlan insurancePlan = InsurancePlanFactory.createInsurancePlan("Basic Insurance Plan");
+            BasicPlan basicPlan = new BasicPlan();
+            assertEquals(insurancePlan, basicPlan);
+        } catch (ParseException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void createInsurancePlanByString_invalidString() {
+        try {
+            InsurancePlan insurancePlan = InsurancePlanFactory.createInsurancePlan("Invalid String");
+            fail();
+        } catch (ParseException e) {
+            assertEquals(e.getMessage(), InsurancePlanFactory.INVALID_PLAN_NAME_MESSAGE);
+        }
+    }
+
+    @Test
+    void createInsurancePlanByString_emptyString() {
+        try {
+            InsurancePlan insurancePlan = InsurancePlanFactory.createInsurancePlan("");
+            fail();
+        } catch (ParseException e) {
+            assertEquals(e.getMessage(), InsurancePlanFactory.INVALID_PLAN_NAME_MESSAGE);
+        }
+    }
+
+    // the following test case was created based on an idea suggested by ChatGPT.
+    @Test
+    void createInsurancePlanByString_nullString() {
+        assertThrows(NullPointerException.class, () -> {
+            InsurancePlanFactory.createInsurancePlan(null);
+        });
+    }
+}

--- a/src/test/java/seedu/address/model/person/insurance/InsurancePlansManagerTest.java
+++ b/src/test/java/seedu/address/model/person/insurance/InsurancePlansManagerTest.java
@@ -1,0 +1,87 @@
+package seedu.address.model.person.insurance;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+class InsurancePlansManagerTest {
+
+    private final InsurancePlansManager insurancePlansManager = new InsurancePlansManager();
+
+    @Test
+    void getInsurancePlans_success() {
+        insurancePlansManager.addPlan(new BasicPlan());
+        insurancePlansManager.addPlan(new TravelPlan());
+
+        ArrayList<InsurancePlan> correctPlans = new ArrayList<>();
+        correctPlans.add(new BasicPlan());
+        correctPlans.add(new TravelPlan());
+
+        assertEquals(correctPlans, insurancePlansManager.getInsurancePlans());
+    }
+
+    @Test
+    void addPlan_success() {
+        insurancePlansManager.addPlan(new BasicPlan());
+        assertEquals(insurancePlansManager.getInsurancePlans().get(0), new BasicPlan());
+    }
+
+    @Test
+    void deletePlan() {
+        insurancePlansManager.addPlan(new BasicPlan());
+        insurancePlansManager.addPlan(new TravelPlan());
+        insurancePlansManager.deletePlan(new BasicPlan());
+        assertEquals(insurancePlansManager.getInsurancePlans().get(0), new TravelPlan());
+    }
+
+    @Test
+    void checkIfPlanNotOwnedWhileAdding_unownedPlan_success() {
+        try {
+            insurancePlansManager.checkIfPlanNotOwned(new BasicPlan());
+        } catch (ParseException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void checkIfPlanNotOwnedWhileAdding_ownedPlan_failure() {
+        try {
+            insurancePlansManager.addPlan(new BasicPlan());
+            insurancePlansManager.checkIfPlanNotOwned(new BasicPlan());
+            fail();
+        } catch (ParseException e) {
+            assertEquals(e.getMessage(), InsurancePlansManager.DUPLICATE_PLAN_DETECTED_MESSAGE);
+        }
+    }
+
+    @Test
+    void checkIfPlanOwnedWhileRemoving_ownedPlan_success() {
+        try {
+            insurancePlansManager.addPlan(new BasicPlan());
+            insurancePlansManager.checkIfPlanOwned(new BasicPlan());
+        } catch (ParseException e) {
+            fail();
+        }
+    }
+
+    @Test
+    void checkIfPlanOwnedWhileRemoving_unownedPlan_failure() {
+        try {
+            insurancePlansManager.checkIfPlanOwned(new BasicPlan());
+            fail();
+        } catch (ParseException e) {
+            assertEquals(e.getMessage(), InsurancePlansManager.PLAN_NOT_DETECTED_MESSAGE);
+        }
+    }
+
+    @Test
+    void testToString() {
+        insurancePlansManager.addPlan(new BasicPlan());
+        assertEquals(insurancePlansManager.toString(), new BasicPlan().toString());
+    }
+}


### PR DESCRIPTION
There is not enough tests to ensure robustness of the insurance
plan manager.

This will not allow us to catch regression bugs easily when
new features are implemented.

Let's add some important basic tests to ensure regression catching
is easier in the future.