### PR TITLE
Modify storage for add claim command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -50,4 +50,13 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Formats the {@code ClaimAmount} for display to the user by converting from cents to dollar and cents.
+     * The formatting was generated using ChatGPT.
+     */
+    public static String formatClaimAmount(int claimAmount) {
+        int centsInADollar = 100;
+        return String.format("$%d.%02d", claimAmount / centsInADollar, claimAmount % centsInADollar);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
@@ -31,7 +31,7 @@ public class AddClaimCommand extends Command {
             + PREFIX_CLAIM_AMOUNT + " 10000";
 
     public static final String MESSAGE_SUCCESS =
-            "New claim added to Client: %1$s, under Insurance plan %2$s, with claimId: %3$s, claimAmount: %4$d";
+            "New claim added to Client: %1$s, under Insurance plan %2$s, with claimId: %3$s, claimAmount: %4$s";
 
     public final Index index;
     private final int insuranceId;
@@ -65,6 +65,6 @@ public class AddClaimCommand extends Command {
         Person personToEdit = lastShownList.get(index.getZeroBased());
 
         throw new CommandException(String.format(MESSAGE_SUCCESS, Messages.format(personToEdit),
-                this.insuranceId, this.claimID, this.claimAmount));
+                this.insuranceId, this.claimID, Messages.formatClaimAmount(this.claimAmount)));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CLAIM_AMOUNT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_CLAIM_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE_ID;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
@@ -77,6 +78,10 @@ public class AddClaimCommand extends Command {
 
             Claim claimToBeAdded = new Claim(claimID, claimAmount);
             personToEditInsurancePlansManager.addClaimToInsurancePlan(planToBeUsed, claimToBeAdded);
+
+            Person personWithAddedInsurancePlan = lastShownList.get(index.getZeroBased());
+            model.setPerson(personToEdit, personWithAddedInsurancePlan);
+            model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
             return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(personToEdit), planToBeUsed,
                     claimID, Messages.formatClaimAmount(claimAmount)));

--- a/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CLAIM_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CLAIM_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE_ID;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Adds a claim to an existing person with existing Insurance Plan in the address book.
+ */
+public class AddClaimCommand extends Command {
+    public static final String COMMAND_WORD = "addClaim";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Adds an open claim to the insurance plan of the client identified "
+            + "by their client id. \n"
+            + "Parameters: INDEX (must be a positive integer), "
+            + " INSURANCE_PLAN_ID (must be a valid ID), "
+            + " Claim_ID (must be a string), "
+            + " Claim amount (must be a valid integer, remove the decimal point) \n"
+            + "Example: " + COMMAND_WORD + " 1 "
+            + PREFIX_INSURANCE_ID + " 0 "
+            + PREFIX_CLAIM_ID + " B1234 "
+            + PREFIX_CLAIM_AMOUNT + " 10000";
+
+    public static final String MESSAGE_SUCCESS =
+            "New claim added to Client: %1$s, under Insurance plan %2$s, with claimId: %3$s, claimAmount: %4$d";
+
+    public final Index index;
+    private final int insuranceId;
+    private final String claimID;
+    private final int claimAmount;
+
+    /**
+     * Constructs an AddClaimCommand object with the values passed in by the user.
+     *
+     * @param index       of the person in the filtered person list to add the insurance plan to.
+     * @param insuranceId of insurance plan the claim is to be added to.
+     * @param claimID     the claimID received when a claim is created through official channels.
+     * @param claimAmount the amount that is being claimed through this claim in cents.
+     */
+    public AddClaimCommand(Index index, int insuranceId, final String claimID, final int claimAmount) {
+        this.index = index;
+        this.insuranceId = insuranceId;
+        this.claimID = claimID;
+        this.claimAmount = claimAmount;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+
+        throw new CommandException(String.format(MESSAGE_SUCCESS, Messages.format(personToEdit),
+                this.insuranceId, this.claimID, this.claimAmount));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
@@ -30,15 +30,16 @@ public class AddInsuranceCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_INSURANCE_ID + " 0";
 
-    public static final String MESSAGE_ARGUMENTS = "Index: %1$d, InsuranceID: %2$s";
     public static final String MESSAGE_ADD_INSURANCE_PLAN_SUCCESS = "Added Insurance Plan: %1$s, to Client: %2$s";
 
     private final Index index;
     private final int insuranceID;
 
     /**
-     * @param index       of the person in the filtered person list to edit the remark
-     * @param insuranceID of the person to be updated to
+     * Constructs an AddInsuranceCommand Object with an Index Object and an integer for insuranceId.
+     *
+     * @param index       of the person in the filtered person list to add the insurance plan to.
+     * @param insuranceID of insurance plan to be added to the person.
      */
     public AddInsuranceCommand(Index index, int insuranceID) {
         requireAllNonNull(index, insuranceID);

--- a/src/main/java/seedu/address/logic/parser/AddClaimCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddClaimCommandParser.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CLAIM_AMOUNT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CLAIM_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE_ID;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.AddClaimCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Creates an {@code AddClaimCommand} object after parsing the user inputs.
+ */
+public class AddClaimCommandParser implements Parser<AddClaimCommand> {
+    /**
+     * Parses {@code userInput} into a command and returns it for execution.
+     *
+     * @throws ParseException if {@code userInput} does not conform the expected format
+     */
+    @Override
+    public AddClaimCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INSURANCE_ID,
+                PREFIX_CLAIM_ID, PREFIX_CLAIM_AMOUNT);
+
+        Index index;
+        int insuranceId;
+        String claimId;
+        int claimAmount;
+
+        try {
+            if (argMultimap.getValue(PREFIX_INSURANCE_ID).isEmpty()
+                    || argMultimap.getValue(PREFIX_CLAIM_ID).isEmpty()
+                    || argMultimap.getValue(PREFIX_CLAIM_AMOUNT).isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        AddClaimCommand.MESSAGE_USAGE));
+            }
+
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            insuranceId = ParserUtil.parseInsurancePlan(argMultimap.getValue(PREFIX_INSURANCE_ID).get());
+            claimId = ParserUtil.parseClaimId(argMultimap.getValue(PREFIX_CLAIM_ID).get());
+            claimAmount = ParserUtil.parseClaimAmount(argMultimap.getValue(PREFIX_CLAIM_AMOUNT).get());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddClaimCommand.MESSAGE_USAGE),
+                    ive);
+        }
+
+        return new AddClaimCommand(index, insuranceId, claimId, claimAmount);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddClaimCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddClaimCommandParser.java
@@ -41,10 +41,11 @@ public class AddClaimCommandParser implements Parser<AddClaimCommand> {
 
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
             insuranceId = ParserUtil.parseInsurancePlan(argMultimap.getValue(PREFIX_INSURANCE_ID).get());
+
             claimId = ParserUtil.parseClaimId(argMultimap.getValue(PREFIX_CLAIM_ID).get());
             claimAmount = ParserUtil.parseClaimAmount(argMultimap.getValue(PREFIX_CLAIM_AMOUNT).get());
         } catch (IllegalValueException ive) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddClaimCommand.MESSAGE_USAGE),
+            throw new ParseException(String.format(ive.getMessage(), AddClaimCommand.MESSAGE_USAGE),
                     ive);
         }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.AddClaimCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddInsuranceCommand;
 import seedu.address.logic.commands.ClearCommand;
@@ -84,6 +85,9 @@ public class AddressBookParser {
 
         case DeleteInsuranceCommand.COMMAND_WORD:
             return new DeleteInsuranceCommandParser().parse(arguments);
+
+        case AddClaimCommand.COMMAND_WORD:
+            return new AddClaimCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,6 +11,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_INSURANCE_ID = new Prefix("id/");
-
+    public static final Prefix PREFIX_INSURANCE_ID = new Prefix("iid/");
+    public static final Prefix PREFIX_CLAIM_ID = new Prefix("cid/");
+    public static final Prefix PREFIX_CLAIM_AMOUNT = new Prefix("ca/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -130,6 +130,37 @@ public class ParserUtil {
     }
 
     /**
+     * Parses {@code String claimId} into a valid claimId.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given claimId is invalid based on preset conventions.
+     */
+    public static String parseClaimId(String claimId) throws ParseException {
+        requireNonNull(claimId);
+        return claimId.trim();
+    }
+
+    /**
+     * Parses {@code String claimId} into a valid claimId.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the claim amount is not a valid positive integer
+     */
+    public static int parseClaimAmount(String claimAmount) throws ParseException {
+        requireNonNull(claimAmount);
+        int claimAmountInt;
+        try {
+            claimAmountInt = Integer.parseInt(claimAmount.trim());
+            if (claimAmountInt < 0) {
+                throw new ParseException("Unplayable, Claim Amount cannot be negative");
+            }
+        } catch (NumberFormatException e) {
+            throw new ParseException("Unplayable, claim Amount must be a positive integer");
+        }
+        return claimAmountInt;
+    }
+
+    /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
      */
     public static Set<Tag> parseTags(Collection<String> tags) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -13,6 +13,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.insurance.claim.Claim;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -137,7 +138,9 @@ public class ParserUtil {
      */
     public static String parseClaimId(String claimId) throws ParseException {
         requireNonNull(claimId);
-        return claimId.trim();
+        String trimmedClaimId = claimId.trim();
+        Claim.checkValidClaimId(trimmedClaimId);
+        return trimmedClaimId;
     }
 
     /**
@@ -151,12 +154,10 @@ public class ParserUtil {
         int claimAmountInt;
         try {
             claimAmountInt = Integer.parseInt(claimAmount.trim());
-            if (claimAmountInt < 0) {
-                throw new ParseException("Unplayable, Claim Amount cannot be negative");
-            }
         } catch (NumberFormatException e) {
-            throw new ParseException("Unplayable, claim Amount must be a positive integer");
+            throw new ParseException(Claim.INVALID_CLAIM_AMOUNT);
         }
+        Claim.checkValidClaimAmount(claimAmountInt);
         return claimAmountInt;
     }
 

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlan.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlan.java
@@ -1,5 +1,9 @@
 package seedu.address.model.person.insurance;
 
+import java.util.ArrayList;
+
+import seedu.address.model.person.insurance.claim.Claim;
+
 /**
  * The {@code InsurancePlan} abstract class represents a general blueprint for an insurance plan.
  * It defines common behaviors that can be shared across all types of insurance plans.
@@ -11,6 +15,12 @@ public abstract class InsurancePlan {
      * Unique identifier for the insurance plan, to be determined in each class separately.
      */
     protected int insurancePlanId = -1;
+
+    protected ArrayList<Claim> claims;
+
+    InsurancePlan() {
+        claims = new ArrayList<>();
+    }
 
     /**
      * Retrieves the insurance plan's unique identifier.

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
@@ -5,6 +5,7 @@ import static seedu.address.model.person.insurance.InsurancePlanFactory.createIn
 import java.util.ArrayList;
 
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.insurance.claim.Claim;
 
 /**
  * The {@code InsurancePlansManager} class represents a list manager of InsurancePlans that a client has purchased.
@@ -101,6 +102,20 @@ public class InsurancePlansManager {
         for (InsurancePlan p : insurancePlans) {
             if (p.equals(plan)) {
                 throw new ParseException(DUPLICATE_PLAN_DETECTED_MESSAGE);
+            }
+        }
+    }
+
+    /**
+     * Adds a claim to the insurance plan of the client.
+     * 
+     * @param insurancePlan The insurance plan the claim is to be added to.
+     * @param claim The claim that is to be added to the insurance plan.
+     */
+    public void addClaimToInsurancePlan(InsurancePlan insurancePlan, Claim claim) {
+        for (InsurancePlan p : insurancePlans) {
+            if (p.equals(insurancePlan)) {
+                p.claims.add(claim);
             }
         }
     }

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
@@ -3,7 +3,9 @@ package seedu.address.model.person.insurance;
 import static seedu.address.model.person.insurance.InsurancePlanFactory.createInsurancePlan;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.insurance.claim.Claim;
 
@@ -17,14 +19,18 @@ public class InsurancePlansManager {
             + "has already been added to this client: %2$s";
     public static final String PLAN_NOT_DETECTED_MESSAGE = "This plan with id: %1$s, "
             + "has not been added to this client: %2$s";
+    public static final String DUPLICATE_CLAIM_ID_MESSAGE = "This claim with id: %1$s "
+            + "has already been added to this client: %2$s";
 
     private final ArrayList<InsurancePlan> insurancePlans;
+    private final HashSet<String> claimIds;
 
     /**
      * Constructs an empty InsurancePlans list.
      */
     public InsurancePlansManager() {
         this.insurancePlans = new ArrayList<>();
+        this.claimIds = new HashSet<>();
     }
 
     /**
@@ -108,14 +114,19 @@ public class InsurancePlansManager {
 
     /**
      * Adds a claim to the insurance plan of the client.
-     * 
+     *
      * @param insurancePlan The insurance plan the claim is to be added to.
-     * @param claim The claim that is to be added to the insurance plan.
+     * @param claim         The claim that is to be added to the insurance plan.
+     * @throws CommandException if the claimId already exists.
      */
-    public void addClaimToInsurancePlan(InsurancePlan insurancePlan, Claim claim) {
+    public void addClaimToInsurancePlan(InsurancePlan insurancePlan, Claim claim) throws CommandException {
+        if (this.claimIds.contains(claim.getClaimId())) {
+            throw new CommandException(DUPLICATE_CLAIM_ID_MESSAGE);
+        }
         for (InsurancePlan p : insurancePlans) {
             if (p.equals(insurancePlan)) {
                 p.claims.add(claim);
+                this.claimIds.add(claim.getClaimId());
             }
         }
     }

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
@@ -117,11 +117,11 @@ public class InsurancePlansManager {
      *
      * @param insurancePlan The insurance plan the claim is to be added to.
      * @param claim         The claim that is to be added to the insurance plan.
-     * @throws CommandException if the claimId already exists.
+     * @throws ParseException if the claimId already exists.
      */
-    public void addClaimToInsurancePlan(InsurancePlan insurancePlan, Claim claim) throws CommandException {
+    public void addClaimToInsurancePlan(InsurancePlan insurancePlan, Claim claim) throws ParseException {
         if (this.claimIds.contains(claim.getClaimId())) {
-            throw new CommandException(DUPLICATE_CLAIM_ID_MESSAGE);
+            throw new ParseException(DUPLICATE_CLAIM_ID_MESSAGE);
         }
         for (InsurancePlan p : insurancePlans) {
             if (p.equals(insurancePlan)) {

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
@@ -5,7 +5,6 @@ import static seedu.address.model.person.insurance.InsurancePlanFactory.createIn
 import java.util.ArrayList;
 import java.util.HashSet;
 
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.insurance.claim.Claim;
 

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
@@ -4,6 +4,7 @@ import static seedu.address.model.person.insurance.InsurancePlanFactory.createIn
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Objects;
 
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.insurance.claim.Claim;
@@ -127,6 +128,62 @@ public class InsurancePlansManager {
                 p.claims.add(claim);
                 this.claimIds.add(claim.getClaimId());
             }
+        }
+    }
+
+    /**
+     * Converts all claims into a string to be saved in JSON file.
+     */
+    public String convertClaimsToJson() {
+        StringBuilder claimsStringBuilder = new StringBuilder();
+        for (InsurancePlan p : this.insurancePlans) {
+            for (Claim c : p.claims) {
+                claimsStringBuilder.append(p.toString())
+                        .append("|")
+                        .append(c.getClaimId())
+                        .append("|")
+                        .append(c.getOpen())
+                        .append("|")
+                        .append(c.getClaimAmount())
+                        .append(",");
+            }
+        }
+
+        if (!claimsStringBuilder.isEmpty()) {
+            claimsStringBuilder.deleteCharAt(claimsStringBuilder.length() - 1);
+        } else {
+            claimsStringBuilder.append("No claims yet.");
+        }
+
+        return claimsStringBuilder.toString();
+    }
+
+    /**
+     * Adds all the claims string from JSON file into their respective insurance plans.
+     *
+     * @param claimsJson String obtained from JSON file of all the claims.
+     * @throws ParseException if there is an error parsing the data from the JSON file.
+     */
+    public void addAllClaimsFromJson(String claimsJson) throws ParseException {
+        String[] claimsString = claimsJson.split(",");
+
+        if (Objects.equals(claimsString[0], "No claims yet.")) {
+            return;
+        }
+
+        for (String claim : claimsString) {
+            String[] claimAttributes = claim.split("\\|");
+
+            InsurancePlan insurancePlan = createInsurancePlan(claimAttributes[0]);
+            checkIfPlanOwned(insurancePlan);
+
+            String claimId = claimAttributes[1];
+            boolean isOpen = Boolean.parseBoolean(claimAttributes[2]);
+            int claimAmount = Integer.parseInt(claimAttributes[3]);
+
+            Claim claimToBeAdded = new Claim(claimId, isOpen, claimAmount);
+
+            this.addClaimToInsurancePlan(insurancePlan, claimToBeAdded);
         }
     }
 

--- a/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/person/insurance/InsurancePlansManager.java
@@ -188,6 +188,21 @@ public class InsurancePlansManager {
     }
 
     /**
+     * Returns the number of open claims for all the insurance plans owned by the client.
+     */
+    public int getNumberOfOpenClaims() {
+        int count = 0;
+        for (InsurancePlan p : this.insurancePlans) {
+            for (Claim c : p.claims) {
+                if (c.getOpen()) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    /**
      * Returns a string representation of the insurance plans.
      * The string will contain the names of all insurance plans in the list.
      * If no plans exist, it returns "Insurance Plans: None".

--- a/src/main/java/seedu/address/model/person/insurance/claim/Claim.java
+++ b/src/main/java/seedu/address/model/person/insurance/claim/Claim.java
@@ -1,0 +1,80 @@
+package seedu.address.model.person.insurance.claim;
+
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * An object that represents a claim that the client has made under an insurance plan.
+ */
+public class Claim {
+    public static final String INVALID_CLAIM_ID = "Invalid Claim ID, must follow: "
+            + "Letter + 4 digits only.";
+
+    public static final String NEGATIVE_CLAIM_AMOUNT = "Claim Amount cannot be negative";
+    public static final String INVALID_CLAIM_AMOUNT = "Claim Amount must be a positive integer";
+
+    private final String claimId;
+    private final boolean claimStatus;
+    private final int claimAmount;
+
+    /**
+     * Constructs a claim object based on the input parameters.
+     *
+     * @param claimId     claim id obtained through official channels.
+     * @param claimStatus current status of the claim, only takes a boolean value.
+     * @param claimAmount claim amount recorded in cents, can only be a positive integer.
+     */
+    public Claim(String claimId, boolean claimStatus, int claimAmount) {
+        this.claimId = claimId;
+        this.claimStatus = claimStatus;
+        this.claimAmount = claimAmount;
+    }
+
+    /**
+     * Returns the {@code claimId} of this claim object.
+     */
+    public String getClaimId() {
+        return this.claimId;
+    }
+
+    /**
+     * Returns the {@code claimStatus} of this claim object.
+     */
+    public boolean getClaimStatus() {
+        return this.claimStatus;
+    }
+
+    /**
+     * Returns the {@code claimAmount} of this claim object.
+     */
+    public int getClaimAmount() {
+        return this.claimAmount;
+    }
+
+    /**
+     * Checks if the claim id is valid based on preset notations.
+     * Regular expression pattern:
+     * ^ - start of the string
+     * [A-Za-z] - any uppercase or lowercase letter
+     * \d{4} - exactly 4 digits
+     * $ - end of the string
+     * This method was created with the aid of ChatGPT.
+     *
+     * @param claimId the claimId string to be checked for validity.
+     * @throws ParseException if the claimId is invalid.
+     */
+    public static void checkValidClaimId(String claimId) throws ParseException {
+        String pattern = "^[A-Za-z]\\d{4}$";
+        if (!claimId.matches(pattern)) {
+            throw new ParseException(INVALID_CLAIM_ID);
+        }
+    }
+
+    /**
+     * Checks if the value of the claim amount is non-negative.
+     */
+    public static void checkValidClaimAmount(int claimAmount) throws ParseException {
+        if (claimAmount < 0) {
+            throw new ParseException(Claim.NEGATIVE_CLAIM_AMOUNT);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/insurance/claim/Claim.java
+++ b/src/main/java/seedu/address/model/person/insurance/claim/Claim.java
@@ -13,41 +13,33 @@ public class Claim {
     public static final String INVALID_CLAIM_AMOUNT = "Claim Amount must be a positive integer";
 
     private final String claimId;
-    private final boolean claimStatus;
+    private final boolean isOpen;
     private final int claimAmount;
 
     /**
-     * Constructs a claim object based on the input parameters.
+     * Creates a new open Claim based on claim id and amount. This constructor is used when user creates a new claim.
      *
      * @param claimId     claim id obtained through official channels.
-     * @param claimStatus current status of the claim, only takes a boolean value.
      * @param claimAmount claim amount recorded in cents, can only be a positive integer.
      */
-    public Claim(String claimId, boolean claimStatus, int claimAmount) {
+    public Claim(String claimId, int claimAmount) {
         this.claimId = claimId;
-        this.claimStatus = claimStatus;
+        this.isOpen = false;
         this.claimAmount = claimAmount;
     }
 
     /**
-     * Returns the {@code claimId} of this claim object.
+     * Constructs a claim object based on the input parameters. This constructor is used, usually during loading of
+     * claims.
+     *
+     * @param claimId     claim id obtained through official channels.
+     * @param isOpen      current status of the claim, only takes a boolean value.
+     * @param claimAmount claim amount recorded in cents, can only be a positive integer.
      */
-    public String getClaimId() {
-        return this.claimId;
-    }
-
-    /**
-     * Returns the {@code claimStatus} of this claim object.
-     */
-    public boolean getClaimStatus() {
-        return this.claimStatus;
-    }
-
-    /**
-     * Returns the {@code claimAmount} of this claim object.
-     */
-    public int getClaimAmount() {
-        return this.claimAmount;
+    public Claim(String claimId, boolean isOpen, int claimAmount) {
+        this.claimId = claimId;
+        this.isOpen = isOpen;
+        this.claimAmount = claimAmount;
     }
 
     /**
@@ -76,5 +68,26 @@ public class Claim {
         if (claimAmount < 0) {
             throw new ParseException(Claim.NEGATIVE_CLAIM_AMOUNT);
         }
+    }
+
+    /**
+     * Returns the {@code claimId} of this claim object.
+     */
+    public String getClaimId() {
+        return this.claimId;
+    }
+
+    /**
+     * Returns the {@code claimStatus} of this claim object.
+     */
+    public boolean getOpen() {
+        return this.isOpen;
+    }
+
+    /**
+     * Returns the {@code claimAmount} of this claim object.
+     */
+    public int getClaimAmount() {
+        return this.claimAmount;
     }
 }

--- a/src/main/java/seedu/address/model/person/insurance/claim/Claim.java
+++ b/src/main/java/seedu/address/model/person/insurance/claim/Claim.java
@@ -18,13 +18,14 @@ public class Claim {
 
     /**
      * Creates a new open Claim based on claim id and amount. This constructor is used when user creates a new claim.
+     * The isOpen attribute will take a default value of {@code true} using this constructor.
      *
      * @param claimId     claim id obtained through official channels.
      * @param claimAmount claim amount recorded in cents, can only be a positive integer.
      */
     public Claim(String claimId, int claimAmount) {
         this.claimId = claimId;
-        this.isOpen = false;
+        this.isOpen = true;
         this.claimAmount = claimAmount;
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.insurance.InsurancePlansManager;
+import seedu.address.model.person.insurance.claim.Claim;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -30,6 +31,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final String insurancePlans;
+    private final String claims;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -38,13 +40,14 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("insurancePlans") String insurancePlansString,
+            @JsonProperty("insurancePlans") String insurancePlansString, @JsonProperty("claims") String claimsString,
             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.insurancePlans = insurancePlansString;
+        this.claims = claimsString;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -59,6 +62,7 @@ class JsonAdaptedPerson {
         email = source.getEmail().value;
         address = source.getAddress().value;
         insurancePlans = source.getInsurancePlansManager().toString();
+        claims = source.getInsurancePlansManager().convertClaimsToJson();
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -111,7 +115,14 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     InsurancePlansManager.class.getSimpleName()));
         }
+
+        if (claims == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Claim.class.getSimpleName()));
+        }
+
         final InsurancePlansManager modelInsurancePlansManager = new InsurancePlansManager(insurancePlans);
+        modelInsurancePlansManager.addAllClaimsFromJson(claims);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelInsurancePlansManager, modelTags);

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -5,12 +5,14 @@
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "tags": [ "friends" ]
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -6,6 +6,7 @@
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "tags" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
@@ -13,6 +14,7 @@
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "tags" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -20,6 +22,7 @@
     "email" : "heinz@example.com",
     "address" : "wall street",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "tags" : [ ]
   }, {
     "name" : "Daniel Meier",
@@ -27,6 +30,7 @@
     "email" : "cornelia@example.com",
     "address" : "10th street",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "tags" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
@@ -34,6 +38,7 @@
     "email" : "werner@example.com",
     "address" : "michegan ave",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "tags" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -41,6 +46,7 @@
     "email" : "lydia@example.com",
     "address" : "little tokyo",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "tags" : [ ]
   }, {
     "name" : "George Best",
@@ -48,6 +54,7 @@
     "email" : "anna@example.com",
     "address" : "4th street",
     "insurancePlans" : "No added plans",
+    "claims" : "No claims yet.",
     "tags" : [ ]
   } ]
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -29,6 +29,7 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final String VALID_INSURANCE_PLANS = BENSON.getInsurancePlansManager().toString();
+    private static final String VALID_CLAIMS = BENSON.getInsurancePlansManager().convertClaimsToJson();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -43,7 +44,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_INSURANCE_PLANS, VALID_TAGS);
+                        VALID_INSURANCE_PLANS, VALID_CLAIMS, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -51,7 +52,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_INSURANCE_PLANS, VALID_TAGS);
+                VALID_INSURANCE_PLANS, VALID_CLAIMS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -60,7 +61,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_INSURANCE_PLANS, VALID_TAGS);
+                        VALID_INSURANCE_PLANS, VALID_CLAIMS, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -68,7 +69,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_INSURANCE_PLANS, VALID_TAGS);
+                VALID_INSURANCE_PLANS, VALID_CLAIMS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -77,7 +78,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                        VALID_INSURANCE_PLANS, VALID_TAGS);
+                        VALID_INSURANCE_PLANS, VALID_CLAIMS, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -85,7 +86,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_INSURANCE_PLANS, VALID_TAGS);
+                VALID_INSURANCE_PLANS, VALID_CLAIMS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -94,7 +95,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                        VALID_INSURANCE_PLANS, VALID_TAGS);
+                        VALID_INSURANCE_PLANS, VALID_CLAIMS, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -102,7 +103,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_INSURANCE_PLANS, VALID_TAGS);
+                VALID_INSURANCE_PLANS, VALID_CLAIMS, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -113,7 +114,7 @@ public class JsonAdaptedPersonTest {
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                        VALID_INSURANCE_PLANS, invalidTags);
+                        VALID_INSURANCE_PLANS, VALID_CLAIMS, invalidTags);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -106,6 +106,20 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Adds all the clients current claims using the {@code InsurancePlansManager}
+     * of the {@code Person} that we are building.
+     */
+    public PersonBuilder withClaims(String claimsString) {
+        assert this.insurancePlansManager != null;
+        try {
+            this.insurancePlansManager.addAllClaimsFromJson(claimsString);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return this;
+    }
+
     public Person build() {
         return new Person(name, phone, email, address, insurancePlansManager, tags);
     }


### PR DESCRIPTION
Enable Long term storage of claims

Claims are forgotten once the app is closed.

This makes the app unusable to the user.

Let's add claims objects to long term storage to make the app more
useful for users.