### PR TITLE
Fix test for DeleteClaimCommand.java

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClaimCommand.java
@@ -79,7 +79,7 @@ public class DeleteClaimCommand extends Command {
             model.setClient(clientToEdit, clientWithDeletedClaim);
             model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
-            return new CommandResult(String.format(MESSAGE_DELETE_CLAIM_SUCCESS, Messages.format(clientToEdit),
+            return new CommandResult(String.format(MESSAGE_DELETE_CLAIM_SUCCESS, clientToEdit.getName().toString(),
                     planToBeUsed, claimId));
         } catch (ClaimException e) {
             throw new CommandException(String.format(e.getMessage(), claimId, Messages.format(clientToEdit)));

--- a/src/test/java/seedu/address/logic/commands/DeleteClaimCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClaimCommandTest.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CLIENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.client.Client;
+import seedu.address.model.client.exceptions.ClaimException;
+import seedu.address.model.client.exceptions.InsurancePlanException;
+import seedu.address.model.client.insurance.InsurancePlan;
+import seedu.address.model.client.insurance.InsurancePlansManager;
+import seedu.address.model.client.insurance.claim.Claim;
+
+class DeleteClaimCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() throws CommandException,
+            InsurancePlanException, ClaimException {
+        ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        Client clientToEdit = model.getFilteredClientList().get(INDEX_THIRD_CLIENT.getZeroBased());
+        InsurancePlan insurancePlan = clientToEdit.getInsurancePlansManager().getInsurancePlan(0);
+        Claim claim = clientToEdit.getInsurancePlansManager().getInsurancePlan(0).getClaim("A1001");
+
+        DeleteClaimCommand deleteClaimCommand =
+                new DeleteClaimCommand(INDEX_THIRD_CLIENT, 0, claim.getClaimId());
+
+        // make sure all the messages only have client name inside the actual classes
+        // because when the message is created here before deletion there can be issues with the
+        // the string comparison of the client after deletion and before deletion.
+        String expectedMessage = String.format(DeleteClaimCommand.MESSAGE_DELETE_CLAIM_SUCCESS,
+                clientToEdit.getName().toString(), insurancePlan, claim.getClaimId());
+
+        // rebuilds a copy of the claims from string to prevent same-object manipulation
+        String insurancePlanString = insurancePlan.toString();
+        String claimsString = clientToEdit.getInsurancePlansManager().convertClaimsToJson();
+        InsurancePlansManager updatedInsurancePlanManager = new InsurancePlansManager(insurancePlanString);
+        updatedInsurancePlanManager.addAllClaimsFromJson(claimsString);
+
+        Client updatedClient = new Client(clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
+                clientToEdit.getAddress(), updatedInsurancePlanManager, clientToEdit.getTags());
+
+        expectedModel.setClient(clientToEdit, updatedClient);
+
+        assertCommandSuccess(deleteClaimCommand, model, expectedMessage, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalClients.java
+++ b/src/test/java/seedu/address/testutil/TypicalClients.java
@@ -35,6 +35,7 @@ public class TypicalClients {
     public static final Client CARL = new ClientBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com")
             .withInsurancePlansManager("Basic Insurance Plan")
+            .withClaims("Basic Insurance Plan|A1001|true|10000")
             .withAddress("wall street").build();
     public static final Client DANIEL = new ClientBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();


### PR DESCRIPTION
Some weird behaviours only found during the testing phase.

The persisting issue is that the models point to the same insurance plan manager object when manipulating one of the models. In the actual application this is not an issue as only one model can exist at a time. However, in the testing environment, there are two models existing at once.

This creates weird behaviours when comparing the insurance plan managers between 2 models as deleting a claim in one model also deletes it in the second model, throwing errors in the test.

Let's fix this by creating a new object using the JSON string methods in the insurance plan manager class.

This will create 2 separate objects preventing the manipulation in one of the models to affect the second, allowing the tests to pass.