### PR TITLE
Add auto sort

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
@@ -67,12 +67,12 @@ public class CloseClaimCommand extends Command {
         Client clientToCloseClaim = lastShownList.get(index.getZeroBased());
 
         try {
-
             InsurancePlansManager clientToEditInsurancePlansManager = clientToCloseClaim.getInsurancePlansManager();
             InsurancePlan planToBeUsed = clientToEditInsurancePlansManager.getInsurancePlan(insuranceId);
+            clientToEditInsurancePlansManager.checkIfPlanOwned(planToBeUsed);
 
             Claim claimToBeMarkedAsClosed = planToBeUsed.getClaim(claimId);
-            claimToBeMarkedAsClosed.close();
+            clientToEditInsurancePlansManager.closeClaim(planToBeUsed, claimToBeMarkedAsClosed);
 
             Client clientWithClosedClaim = lastShownList.get(index.getZeroBased());
             model.setClient(clientToCloseClaim, clientWithClosedClaim);

--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlan.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlan.java
@@ -72,7 +72,7 @@ public abstract class InsurancePlan {
     }
 
     /**
-     * Sorts the claims of this insurance plan only based on claim status then by claim id.
+     * Sorts the claims of this insurance plan only based on claim status then by claim ID.
      */
     public void sortClaims() {
         ClaimComparator claimComparator = new ClaimComparator();

--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlan.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlan.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 
 import seedu.address.model.client.exceptions.ClaimException;
 import seedu.address.model.client.insurance.claim.Claim;
+import seedu.address.model.client.insurance.claim.ClaimComparator;
 
 /**
  * The {@code InsurancePlan} abstract class represents a general blueprint for an insurance plan.
@@ -51,12 +52,31 @@ public abstract class InsurancePlan {
     }
 
     /**
+     * Adds a claim to the insurance plan's list of claims.
+     *
+     * @param claim The claim to be added.
+     */
+    public void addClaim(Claim claim) {
+        claims.add(claim);
+        sortClaims();
+    }
+
+    /**
      * Removes a claim from the insurance plan's list of claims.
      *
      * @param claim The claim to be removed.
      */
     public void removeClaim(Claim claim) {
         claims.remove(claim);
+        sortClaims();
+    }
+
+    /**
+     * Sorts the claims of this insurance plan only based on claim status then by claim id.
+     */
+    public void sortClaims() {
+        ClaimComparator claimComparator = new ClaimComparator();
+        this.claims.sort(claimComparator);
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
@@ -139,7 +139,7 @@ public class InsurancePlansManager {
     }
 
     /**
-     * Adds a claim to the insurance plan of the client.
+     * Adds a claim to the insurance plan of the client. NOTE: Part of this can be moved to {@code InsurancePlan} later.
      *
      * @param insurancePlan The insurance plan the claim is to be added to.
      * @param claim         The claim that is to be added to the insurance plan.
@@ -151,7 +151,7 @@ public class InsurancePlansManager {
         }
         for (InsurancePlan p : insurancePlans) {
             if (p.equals(insurancePlan)) {
-                p.claims.add(claim);
+                p.addClaim(claim);
                 this.claimIds.add(claim.getClaimId());
             }
         }

--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
@@ -4,6 +4,7 @@ import static seedu.address.model.client.insurance.InsurancePlanFactory.createIn
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.logging.Logger;
 
 import seedu.address.model.client.exceptions.ClaimException;
 import seedu.address.model.client.exceptions.InsurancePlanException;
@@ -75,7 +76,7 @@ public class InsurancePlansManager {
      *                                the client's list of insurance plans.
      */
     public InsurancePlan getInsurancePlan(int insuranceId) throws InsurancePlanException {
-        for (InsurancePlan plan : insurancePlans) {
+        for (InsurancePlan plan : this.insurancePlans) {
             if (plan.getInsurancePlanId() == insuranceId) {
                 return plan;
             }
@@ -115,6 +116,7 @@ public class InsurancePlansManager {
     public void checkIfPlanOwned(InsurancePlan plan) throws InsurancePlanException {
         for (InsurancePlan p : insurancePlans) {
             if (p.getInsurancePlanId() == plan.getInsurancePlanId()) {
+
                 return;
             }
         }
@@ -150,7 +152,7 @@ public class InsurancePlansManager {
             throw new ClaimException(DUPLICATE_CLAIM_ID_MESSAGE);
         }
         for (InsurancePlan p : insurancePlans) {
-            if (p.equals(insurancePlan)) {
+            if (p.insurancePlanId == insurancePlan.getInsurancePlanId()) {
                 p.addClaim(claim);
                 this.claimIds.add(claim.getClaimId());
             }
@@ -165,11 +167,22 @@ public class InsurancePlansManager {
      */
     public void deleteClaimFromInsurancePlan(InsurancePlan insurancePlan, Claim claim) {
         for (InsurancePlan p : insurancePlans) {
-            if (p.equals(insurancePlan)) {
+            if (p.insurancePlanId == insurancePlan.getInsurancePlanId()) {
                 p.removeClaim(claim);
                 this.claimIds.remove(claim.getClaimId());
             }
         }
+    }
+
+    /**
+     * Closes a claim from the specified insurance plan of the client.
+     *
+     * @param planToBeUsed            The insurance plan the claim belongs to.
+     * @param claimToBeMarkedAsClosed The claim to be marked as closed.
+     */
+    public void closeClaim(InsurancePlan planToBeUsed, Claim claimToBeMarkedAsClosed) {
+        claimToBeMarkedAsClosed.close();
+        planToBeUsed.sortClaims();
     }
 
     /**
@@ -245,20 +258,20 @@ public class InsurancePlansManager {
 
     /**
      * Retrieves a formatted string listing all claims associated with the insurance plans.
-     *
+     * <p>
      * This method constructs a string representation of claims for each insurance plan
      * managed by the current entity. If there are no insurance plans, it returns a message
      * indicating that there are no insurance plans available. For each insurance plan,
      * it lists the claims, and if a plan has no claims, it appends a message indicating that
      * there are no claims for that particular plan.
-     *
+     * <p>
      * The format of the returned string is as follows:
      * - For each insurance plan, it includes the plan's details.
      * - If an insurance plan has no claims, it appends {@link #NO_CLAIMS_MESSAGE}.
      * - If claims exist, they are listed with an index number.
      *
      * @return A string representation of all claims associated with the insurance plans,
-     *         or {@link #NO_INSURANCE_PLANS_MESSAGE} if there are no insurance plans.
+     *     or {@link #NO_INSURANCE_PLANS_MESSAGE} if there are no insurance plans.
      */
     public String accessClaims() {
         StringBuilder listOfClaims = new StringBuilder();

--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
@@ -4,7 +4,6 @@ import static seedu.address.model.client.insurance.InsurancePlanFactory.createIn
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.logging.Logger;
 
 import seedu.address.model.client.exceptions.ClaimException;
 import seedu.address.model.client.exceptions.InsurancePlanException;

--- a/src/main/java/seedu/address/model/client/insurance/claim/ClaimComparator.java
+++ b/src/main/java/seedu/address/model/client/insurance/claim/ClaimComparator.java
@@ -44,10 +44,10 @@ public class ClaimComparator implements Comparator<Claim> {
     @Override
     public int compare(Claim o1, Claim o2) {
         if (o1.getClaimStatus() && !o2.getClaimStatus()) {
-            return 1;
+            return -1;
         }
         if (o2.getClaimStatus() && !o1.getClaimStatus()) {
-            return -1;
+            return 1;
         }
         return o1.getClaimId().toUpperCase().compareTo(o2.getClaimId().toUpperCase());
     }

--- a/src/main/java/seedu/address/model/client/insurance/claim/ClaimComparator.java
+++ b/src/main/java/seedu/address/model/client/insurance/claim/ClaimComparator.java
@@ -1,0 +1,54 @@
+package seedu.address.model.client.insurance.claim;
+
+import java.util.Comparator;
+
+/**
+ * Implements a comparator to compare claims.
+ */
+public class ClaimComparator implements Comparator<Claim> {
+
+    /**
+     * Compares its two arguments for order.  Returns a negative integer,
+     * zero, or a positive integer as the first argument is less than, equal
+     * to, or greater than the second.<p>
+     * <p>
+     * The implementor must ensure that {@link Integer#signum
+     * signum}{@code (compare(x, y)) == -signum(compare(y, x))} for
+     * all {@code x} and {@code y}.  (This implies that {@code
+     * compare(x, y)} must throw an exception if and only if {@code
+     * compare(y, x)} throws an exception.)<p>
+     * <p>
+     * The implementor must also ensure that the relation is transitive:
+     * {@code ((compare(x, y)>0) && (compare(y, z)>0))} implies
+     * {@code compare(x, z)>0}.<p>
+     * <p>
+     * Finally, the implementor must ensure that {@code compare(x,
+     * y)==0} implies that {@code signum(compare(x,
+     * z))==signum(compare(y, z))} for all {@code z}.
+     *
+     * @param o1 the first claim to be compared.
+     * @param o2 the second claim to be compared.
+     * @return a negative integer, zero, or a positive integer as the
+     *     first argument is less than, equal to, or greater than the
+     *     second.
+     * @throws NullPointerException if an argument is null and this
+     *                              comparator does not permit null arguments
+     * @throws ClassCastException   if the arguments' types prevent them from
+     *                              being compared by this comparator.
+     * @apiNote It is generally the case, but <i>not</i> strictly required that
+     *     {@code (compare(x, y)==0) == (x.equals(y))}.  Generally speaking,
+     *     any comparator that violates this condition should clearly indicate
+     *     this fact.  The recommended language is "Note: this comparator
+     *     imposes orderings that are inconsistent with equals."
+     */
+    @Override
+    public int compare(Claim o1, Claim o2) {
+        if (o1.getClaimStatus() && !o2.getClaimStatus()) {
+            return 1;
+        }
+        if (o2.getClaimStatus() && !o1.getClaimStatus()) {
+            return -1;
+        }
+        return o1.getClaimId().toUpperCase().compareTo(o2.getClaimId().toUpperCase());
+    }
+}


### PR DESCRIPTION
Currently, the claims are sorted in the order in which they are added. They should instead appear in lexicographical order which would be more appropriate. They should be sorted automatically once the new claim is added.

Fixed some weird bugs with adding of more than 1 claim, as well as some minor modifications to the close claim command.

Fixed #121 