### PR TITLE
Add method to check insurance commands and update some test methods.

### DIFF
--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
@@ -179,8 +179,13 @@ public class InsurancePlansManager {
      * @param planToBeUsed            The insurance plan the claim belongs to.
      * @param claimToBeMarkedAsClosed The claim to be marked as closed.
      */
-    public void closeClaim(InsurancePlan planToBeUsed, Claim claimToBeMarkedAsClosed) {
-        claimToBeMarkedAsClosed.close();
+    public void closeClaim(InsurancePlan planToBeUsed, Claim claimToBeMarkedAsClosed) throws ClaimException {
+        for (InsurancePlan p : insurancePlans) {
+            if (p.insurancePlanId == planToBeUsed.getInsurancePlanId()) {
+                Claim claimToClose = p.getClaim(claimToBeMarkedAsClosed.getClaimId());
+                claimToClose.close();
+            }
+        }
         planToBeUsed.sortClaims();
     }
 
@@ -331,5 +336,18 @@ public class InsurancePlansManager {
             return true;
         }
         return false;
+    }
+
+    /**
+     * Creates a copy of this object for testing purposes only.
+     */
+    public InsurancePlansManager createCopy() throws InsurancePlanException, ClaimException {
+        String jsonPlansString = toString();
+        InsurancePlansManager copy = new InsurancePlansManager(jsonPlansString);
+
+        String jsonClaimsString = this.convertClaimsToJson();
+        copy.addAllClaimsFromJson(jsonClaimsString);
+
+        return copy;
     }
 }

--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
@@ -115,7 +115,6 @@ public class InsurancePlansManager {
     public void checkIfPlanOwned(InsurancePlan plan) throws InsurancePlanException {
         for (InsurancePlan p : insurancePlans) {
             if (p.getInsurancePlanId() == plan.getInsurancePlanId()) {
-
                 return;
             }
         }
@@ -140,7 +139,7 @@ public class InsurancePlansManager {
     }
 
     /**
-     * Adds a claim to the insurance plan of the client. NOTE: Part of this can be moved to {@code InsurancePlan} later.
+     * Adds a claim to the insurance plan of the client.
      *
      * @param insurancePlan The insurance plan the claim is to be added to.
      * @param claim         The claim that is to be added to the insurance plan.

--- a/src/test/java/seedu/address/logic/commands/AddInsuranceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddInsuranceCommandTest.java
@@ -3,7 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.assertInsuranceCommandSuccess;
 import static seedu.address.model.client.insurance.InsurancePlanFactory.INVALID_PLAN_ID_MESSAGE;
 import static seedu.address.model.client.insurance.InsurancePlansManager.DUPLICATE_PLAN_DETECTED_MESSAGE;
 import static seedu.address.testutil.TypicalClients.BENSON;
@@ -23,6 +23,7 @@ import seedu.address.model.UserPrefs;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.insurance.InsurancePlan;
 import seedu.address.model.client.insurance.InsurancePlanFactory;
+import seedu.address.model.client.insurance.InsurancePlansManager;
 import seedu.address.testutil.ClientBuilder;
 
 class AddInsuranceCommandTest {
@@ -38,6 +39,7 @@ class AddInsuranceCommandTest {
     public void execute_validIndexValidInsuranceId_success() throws Exception {
         // DANIEL (fourth client) does not have basic insurance plan
         Client originalClient = model.getFilteredClientList().get(INDEX_FOURTH_CLIENT.getZeroBased());
+        InsurancePlansManager originalInsurancePlanManager = originalClient.getInsurancePlansManager();
 
         // Assume valid insurance plan
         int validInsuranceId = 0;
@@ -52,10 +54,12 @@ class AddInsuranceCommandTest {
 
         String expectedMessage = String.format(AddInsuranceCommand.MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
                 planToBeAdded, Messages.format(updatedClient));
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.setClient(originalClient, updatedClient);
 
-        assertCommandSuccess(addInsuranceCommand, model, expectedMessage, expectedModel);
+        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlanManager.createCopy();
+        updatedInsurancePlansManager.addPlan(planToBeAdded);
+
+        assertInsuranceCommandSuccess(addInsuranceCommand, model, expectedMessage,
+                originalInsurancePlanManager, updatedInsurancePlansManager);
     }
 
     /**
@@ -67,6 +71,7 @@ class AddInsuranceCommandTest {
     public void execute_multipleInsurancePlans_success() throws Exception {
         // ELLE (fifth client) does not have any insurance plans
         Client originalClient = model.getFilteredClientList().get(INDEX_FIFTH_CLIENT.getZeroBased());
+        InsurancePlansManager originalInsurancePlanManager = originalClient.getInsurancePlansManager();
 
         // Add first insurance plan (basic insurance plan)
         int firstInsuranceId = 0;
@@ -80,10 +85,12 @@ class AddInsuranceCommandTest {
 
         String firstExpectedMessage = String.format(AddInsuranceCommand.MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
                 firstPlan, Messages.format(clientWithFirstPlan));
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-        expectedModel.setClient(originalClient, clientWithFirstPlan);
 
-        assertCommandSuccess(firstAddCommand, model, firstExpectedMessage, expectedModel);
+        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlanManager.createCopy();
+        updatedInsurancePlansManager.addPlan(firstPlan);
+
+        assertInsuranceCommandSuccess(firstAddCommand, model, firstExpectedMessage,
+                originalInsurancePlanManager, updatedInsurancePlansManager);
 
         // Second insurance plan (travel insurance plan)
         int secondInsuranceId = 1;
@@ -97,10 +104,11 @@ class AddInsuranceCommandTest {
 
         String secondExpectedMessage = String.format(AddInsuranceCommand.MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
                 secondPlan, Messages.format(clientWithBothPlans));
-        ModelManager finalExpectedModel = new ModelManager(expectedModel.getAddressBook(), new UserPrefs());
-        finalExpectedModel.setClient(clientWithFirstPlan, clientWithBothPlans);
 
-        assertCommandSuccess(secondAddCommand, expectedModel, secondExpectedMessage, finalExpectedModel);
+        updatedInsurancePlansManager.addPlan(secondPlan);
+
+        assertInsuranceCommandSuccess(secondAddCommand, model, secondExpectedMessage,
+                originalInsurancePlanManager, updatedInsurancePlansManager);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CloseClaimCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CloseClaimCommandTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.fail;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.assertInsuranceCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CLIENT;
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CLIENT;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -28,9 +27,9 @@ class CloseClaimCommandTest {
     @Test
     void execute_validIndexUnfilteredList_success() throws CommandException,
             InsurancePlanException, ClaimException {
-        ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-
         Client clientToEdit = model.getFilteredClientList().get(INDEX_THIRD_CLIENT.getZeroBased());
+        InsurancePlansManager originalInsurancePlanManager = clientToEdit.getInsurancePlansManager();
+
         InsurancePlan insurancePlan = clientToEdit.getInsurancePlansManager().getInsurancePlan(0);
         Claim claim = clientToEdit.getInsurancePlansManager().getInsurancePlan(0).getClaim("A1001");
 
@@ -43,19 +42,11 @@ class CloseClaimCommandTest {
         String expectedMessage = String.format(CloseClaimCommand.MESSAGE_CLOSE_CLAIM_SUCCESS,
                 clientToEdit.getName().toString(), insurancePlan, claim.getClaimId());
 
-        // rebuilds a copy of the claims from string to prevent same-object manipulation
-        String insurancePlanString = insurancePlan.toString();
-        String claimsString = clientToEdit.getInsurancePlansManager().convertClaimsToJson();
-        InsurancePlansManager updatedInsurancePlanManager = new InsurancePlansManager(insurancePlanString);
-        updatedInsurancePlanManager.addAllClaimsFromJson(claimsString);
+        InsurancePlansManager updatedInsurancePlanManager = originalInsurancePlanManager.createCopy();
         updatedInsurancePlanManager.closeClaim(insurancePlan, claim);
 
-        Client updatedClient = new Client(clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
-                clientToEdit.getAddress(), updatedInsurancePlanManager, clientToEdit.getTags());
-
-        expectedModel.setClient(clientToEdit, updatedClient);
-
-        assertCommandSuccess(closeClaimCommand, model, expectedMessage, expectedModel);
+        assertInsuranceCommandSuccess(closeClaimCommand, model, expectedMessage,
+                originalInsurancePlanManager, updatedInsurancePlanManager);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CloseClaimCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CloseClaimCommandTest.java
@@ -28,7 +28,7 @@ class CloseClaimCommandTest {
     void execute_validIndexUnfilteredList_success() throws CommandException,
             InsurancePlanException, ClaimException {
         Client clientToEdit = model.getFilteredClientList().get(INDEX_THIRD_CLIENT.getZeroBased());
-        InsurancePlansManager originalInsurancePlanManager = clientToEdit.getInsurancePlansManager();
+        InsurancePlansManager originalInsurancePlansManager = clientToEdit.getInsurancePlansManager();
 
         InsurancePlan insurancePlan = clientToEdit.getInsurancePlansManager().getInsurancePlan(0);
         Claim claim = clientToEdit.getInsurancePlansManager().getInsurancePlan(0).getClaim("A1001");
@@ -42,11 +42,11 @@ class CloseClaimCommandTest {
         String expectedMessage = String.format(CloseClaimCommand.MESSAGE_CLOSE_CLAIM_SUCCESS,
                 clientToEdit.getName().toString(), insurancePlan, claim.getClaimId());
 
-        InsurancePlansManager updatedInsurancePlanManager = originalInsurancePlanManager.createCopy();
-        updatedInsurancePlanManager.closeClaim(insurancePlan, claim);
+        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlansManager.createCopy();
+        updatedInsurancePlansManager.closeClaim(insurancePlan, claim);
 
         assertInsuranceCommandSuccess(closeClaimCommand, model, expectedMessage,
-                originalInsurancePlanManager, updatedInsurancePlanManager);
+                originalInsurancePlansManager, updatedInsurancePlansManager);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -122,26 +122,24 @@ public class CommandTestUtil {
      * @param actualModel                  Model that the command is to be checked on.
      * @param expectedMessage              the expected success message.
      * @param actualInsurancePlansManager  the actual state of the insurance plan manager.
-     * @param expectedInsurancePlanManager the expected state of the insurance plan manager.
+     * @param expectedInsurancePlansManager the expected state of the insurance plan manager.
      */
     public static void assertInsuranceCommandSuccess(Command command, Model actualModel, String expectedMessage,
                                                      InsurancePlansManager actualInsurancePlansManager,
-                                                     InsurancePlansManager expectedInsurancePlanManager) {
+                                                     InsurancePlansManager expectedInsurancePlansManager) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertInsuranceCommandSuccess(command, actualModel, expectedCommandResult,
-                actualInsurancePlansManager, expectedInsurancePlanManager);
+                actualInsurancePlansManager, expectedInsurancePlansManager);
     }
 
     private static void assertInsuranceCommandSuccess(Command command, Model actualModel,
                                                       CommandResult expectedCommandResult,
                                                       InsurancePlansManager actualInsurancePlansManager,
-                                                      InsurancePlansManager expectedInsurancePlanManager) {
+                                                      InsurancePlansManager expectedInsurancePlansManager) {
         try {
             CommandResult result = command.execute(actualModel);
-            System.out.println(expectedInsurancePlanManager.convertClaimsToJson());
-            System.out.println(actualInsurancePlansManager.convertClaimsToJson());
             assertEquals(expectedCommandResult, result);
-            assertEquals(expectedInsurancePlanManager, actualInsurancePlansManager);
+            assertEquals(expectedInsurancePlansManager, actualInsurancePlansManager);
         } catch (CommandException ce) {
             throw new AssertionError("Execution of command should not fail.", ce);
         }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -19,6 +19,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.NameContainsKeywordsPredicate;
+import seedu.address.model.client.insurance.InsurancePlansManager;
 import seedu.address.testutil.EditClientDescriptorBuilder;
 
 /**
@@ -75,7 +76,7 @@ public class CommandTestUtil {
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-            Model expectedModel) {
+                                            Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
@@ -90,7 +91,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {
+                                            Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -111,6 +112,41 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredClientList());
     }
+
+    /**
+     * Checks if the {@code InsurancePlansManager} object works as intended when a command is called. This assert method
+     * is required as the {@code InsurancePlansManager} is mutable and has no equals method in {@code Client} to check
+     * for changes using the {@link #assertCommandSuccess(Command, Model, CommandResult, Model)} method.
+     *
+     * @param command                      command to be checked, must be only for Insurance or Claims related objects.
+     * @param actualModel                  Model that the command is to be checked on.
+     * @param expectedMessage              the expected success message.
+     * @param actualInsurancePlansManager  the actual state of the insurance plan manager.
+     * @param expectedInsurancePlanManager the expected state of the insurance plan manager.
+     */
+    public static void assertInsuranceCommandSuccess(Command command, Model actualModel, String expectedMessage,
+                                                     InsurancePlansManager actualInsurancePlansManager,
+                                                     InsurancePlansManager expectedInsurancePlanManager) {
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        assertInsuranceCommandSuccess(command, actualModel, expectedCommandResult,
+                actualInsurancePlansManager, expectedInsurancePlanManager);
+    }
+
+    private static void assertInsuranceCommandSuccess(Command command, Model actualModel,
+                                                      CommandResult expectedCommandResult,
+                                                      InsurancePlansManager actualInsurancePlansManager,
+                                                      InsurancePlansManager expectedInsurancePlanManager) {
+        try {
+            CommandResult result = command.execute(actualModel);
+            System.out.println(expectedInsurancePlanManager.convertClaimsToJson());
+            System.out.println(actualInsurancePlansManager.convertClaimsToJson());
+            assertEquals(expectedCommandResult, result);
+            assertEquals(expectedInsurancePlanManager, actualInsurancePlansManager);
+        } catch (CommandException ce) {
+            throw new AssertionError("Execution of command should not fail.", ce);
+        }
+    }
+
     /**
      * Updates {@code model}'s filtered list to show only the client at the given {@code targetIndex} in the
      * {@code model}'s address book.

--- a/src/test/java/seedu/address/logic/commands/DeleteClaimCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClaimCommandTest.java
@@ -28,9 +28,9 @@ class DeleteClaimCommandTest {
         ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
         Client clientToEdit = model.getFilteredClientList().get(INDEX_THIRD_CLIENT.getZeroBased());
-        InsurancePlansManager originalInsurancePlanManager = clientToEdit.getInsurancePlansManager();
-        InsurancePlan insurancePlan = originalInsurancePlanManager.getInsurancePlan(0);
-        Claim claim = originalInsurancePlanManager.getInsurancePlan(0).getClaim("A1001");
+        InsurancePlansManager originalInsurancePlansManager = clientToEdit.getInsurancePlansManager();
+        InsurancePlan insurancePlan = originalInsurancePlansManager.getInsurancePlan(0);
+        Claim claim = originalInsurancePlansManager.getInsurancePlan(0).getClaim("A1001");
 
         DeleteClaimCommand deleteClaimCommand =
                 new DeleteClaimCommand(INDEX_THIRD_CLIENT, 0, claim.getClaimId());
@@ -42,15 +42,15 @@ class DeleteClaimCommandTest {
                 clientToEdit.getName().toString(), insurancePlan, claim.getClaimId());
 
         // rebuilds a copy of the claims from string to prevent same-object manipulation
-        InsurancePlansManager updatedInsurancePlanManager = originalInsurancePlanManager.createCopy();
-        updatedInsurancePlanManager.deleteClaimFromInsurancePlan(insurancePlan, claim);
+        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlansManager.createCopy();
+        updatedInsurancePlansManager.deleteClaimFromInsurancePlan(insurancePlan, claim);
 
         Client updatedClient = new Client(clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
-                clientToEdit.getAddress(), updatedInsurancePlanManager, clientToEdit.getTags());
+                clientToEdit.getAddress(), updatedInsurancePlansManager, clientToEdit.getTags());
 
         expectedModel.setClient(clientToEdit, updatedClient);
 
         assertInsuranceCommandSuccess(deleteClaimCommand, model, expectedMessage,
-                clientToEdit.getInsurancePlansManager(), updatedInsurancePlanManager);
+                clientToEdit.getInsurancePlansManager(), updatedInsurancePlansManager);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteClaimCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteClaimCommandTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.commands;
 
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.assertInsuranceCommandSuccess;
 import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CLIENT;
 
@@ -28,8 +28,9 @@ class DeleteClaimCommandTest {
         ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
         Client clientToEdit = model.getFilteredClientList().get(INDEX_THIRD_CLIENT.getZeroBased());
-        InsurancePlan insurancePlan = clientToEdit.getInsurancePlansManager().getInsurancePlan(0);
-        Claim claim = clientToEdit.getInsurancePlansManager().getInsurancePlan(0).getClaim("A1001");
+        InsurancePlansManager originalInsurancePlanManager = clientToEdit.getInsurancePlansManager();
+        InsurancePlan insurancePlan = originalInsurancePlanManager.getInsurancePlan(0);
+        Claim claim = originalInsurancePlanManager.getInsurancePlan(0).getClaim("A1001");
 
         DeleteClaimCommand deleteClaimCommand =
                 new DeleteClaimCommand(INDEX_THIRD_CLIENT, 0, claim.getClaimId());
@@ -41,10 +42,7 @@ class DeleteClaimCommandTest {
                 clientToEdit.getName().toString(), insurancePlan, claim.getClaimId());
 
         // rebuilds a copy of the claims from string to prevent same-object manipulation
-        String insurancePlanString = insurancePlan.toString();
-        String claimsString = clientToEdit.getInsurancePlansManager().convertClaimsToJson();
-        InsurancePlansManager updatedInsurancePlanManager = new InsurancePlansManager(insurancePlanString);
-        updatedInsurancePlanManager.addAllClaimsFromJson(claimsString);
+        InsurancePlansManager updatedInsurancePlanManager = originalInsurancePlanManager.createCopy();
         updatedInsurancePlanManager.deleteClaimFromInsurancePlan(insurancePlan, claim);
 
         Client updatedClient = new Client(clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
@@ -52,6 +50,7 @@ class DeleteClaimCommandTest {
 
         expectedModel.setClient(clientToEdit, updatedClient);
 
-        assertCommandSuccess(deleteClaimCommand, model, expectedMessage, expectedModel);
+        assertInsuranceCommandSuccess(deleteClaimCommand, model, expectedMessage,
+                clientToEdit.getInsurancePlansManager(), updatedInsurancePlanManager);
     }
 }

--- a/src/test/java/seedu/address/model/client/insurance/InsurancePlansManagerTest.java
+++ b/src/test/java/seedu/address/model/client/insurance/InsurancePlansManagerTest.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.client.exceptions.ClaimException;
 import seedu.address.model.client.exceptions.InsurancePlanException;
 import seedu.address.model.client.insurance.claim.Claim;
 import seedu.address.model.client.insurance.claim.ClaimStub;
@@ -142,6 +143,14 @@ class InsurancePlansManagerTest {
 
         // Act and Assert
         assertNotEquals(manager1, manager2);
+    }
+
+    @Test
+    public void checkIfCopyIsIdentical_success() throws ClaimException, InsurancePlanException {
+        InsurancePlansManager manager1 = new InsurancePlansManager();
+        InsurancePlansManager manager2 = manager1.createCopy();
+
+        assertEquals(manager1, manager2);
     }
 
 


### PR DESCRIPTION
Fix testing methods for Insurance and Claim Commands

The testing utilities do not support comparison of states of
InsurancePlansManager objects as we purposefully implemented it
as a mutable object and did not include this object to the client's
equals method.

This causes weird testing behaviours as the expected and intended
models used in assertCommandSuccess methods do not really check if
the two InsurancePlansManager objects are indeed the same.

Let's introduce a new testing utility to check for changes in
InsurancePlanManager objects instead of clients.

This should make the testing alot easier and accurate for commands
related to Insurances and Claims.

While using the new tests, uncovered a bug inside close claim
command as the plan marks the object itself as false. This may cause
weird behaviours if say, two claims with same claimIds exist under
different plans.

Let's change this to ensure only the claim inside of the insurance
plan.

This should get rid of any weird behaviours.

The following tests were also updated using the new test utility.

- AddInsuranceCommandTest
- CloseClaimCommandTest
- DeleteClaimCommandTest
