### PR TITLE
Update DeleteInsuranceCommandTest.java

### DIFF
--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
@@ -328,8 +328,8 @@ public class InsurancePlansManager {
         if (this == other) {
             return true;
         } else if (other instanceof InsurancePlansManager) {
-            InsurancePlansManager otherInsurancePlanManager = (InsurancePlansManager) other;
-            if (!otherInsurancePlanManager.insurancePlans.equals(this.insurancePlans)) {
+            InsurancePlansManager otherInsurancePlansManager = (InsurancePlansManager) other;
+            if (!otherInsurancePlansManager.insurancePlans.equals(this.insurancePlans)) {
                 return false;
             }
             return true;

--- a/src/test/java/seedu/address/logic/commands/AddInsuranceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddInsuranceCommandTest.java
@@ -39,7 +39,7 @@ class AddInsuranceCommandTest {
     public void execute_validIndexValidInsuranceId_success() throws Exception {
         // DANIEL (fourth client) does not have basic insurance plan
         Client originalClient = model.getFilteredClientList().get(INDEX_FOURTH_CLIENT.getZeroBased());
-        InsurancePlansManager originalInsurancePlanManager = originalClient.getInsurancePlansManager();
+        InsurancePlansManager originalInsurancePlansManager = originalClient.getInsurancePlansManager();
 
         // Assume valid insurance plan
         int validInsuranceId = 0;
@@ -55,11 +55,11 @@ class AddInsuranceCommandTest {
         String expectedMessage = String.format(AddInsuranceCommand.MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
                 planToBeAdded, Messages.format(updatedClient));
 
-        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlanManager.createCopy();
+        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlansManager.createCopy();
         updatedInsurancePlansManager.addPlan(planToBeAdded);
 
         assertInsuranceCommandSuccess(addInsuranceCommand, model, expectedMessage,
-                originalInsurancePlanManager, updatedInsurancePlansManager);
+                originalInsurancePlansManager, updatedInsurancePlansManager);
     }
 
     /**
@@ -71,7 +71,7 @@ class AddInsuranceCommandTest {
     public void execute_multipleInsurancePlans_success() throws Exception {
         // ELLE (fifth client) does not have any insurance plans
         Client originalClient = model.getFilteredClientList().get(INDEX_FIFTH_CLIENT.getZeroBased());
-        InsurancePlansManager originalInsurancePlanManager = originalClient.getInsurancePlansManager();
+        InsurancePlansManager originalInsurancePlansManager = originalClient.getInsurancePlansManager();
 
         // Add first insurance plan (basic insurance plan)
         int firstInsuranceId = 0;
@@ -86,11 +86,11 @@ class AddInsuranceCommandTest {
         String firstExpectedMessage = String.format(AddInsuranceCommand.MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
                 firstPlan, Messages.format(clientWithFirstPlan));
 
-        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlanManager.createCopy();
+        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlansManager.createCopy();
         updatedInsurancePlansManager.addPlan(firstPlan);
 
         assertInsuranceCommandSuccess(firstAddCommand, model, firstExpectedMessage,
-                originalInsurancePlanManager, updatedInsurancePlansManager);
+                originalInsurancePlansManager, updatedInsurancePlansManager);
 
         // Second insurance plan (travel insurance plan)
         int secondInsuranceId = 1;
@@ -108,7 +108,7 @@ class AddInsuranceCommandTest {
         updatedInsurancePlansManager.addPlan(secondPlan);
 
         assertInsuranceCommandSuccess(secondAddCommand, model, secondExpectedMessage,
-                originalInsurancePlanManager, updatedInsurancePlansManager);
+                originalInsurancePlansManager, updatedInsurancePlansManager);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteInsuranceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteInsuranceCommandTest.java
@@ -2,7 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.assertInsuranceCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CLIENT;
@@ -17,6 +17,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.exceptions.ClaimException;
 import seedu.address.model.client.exceptions.InsurancePlanException;
 import seedu.address.model.client.insurance.InsurancePlan;
 import seedu.address.model.client.insurance.InsurancePlansManager;
@@ -32,17 +33,16 @@ class DeleteInsuranceCommandTest {
      * @throws InsurancePlanException if the insurance plan deletion fails due to internal errors.
      */
     @Test
-    public void execute_validIndexUnfilteredList_success() throws InsurancePlanException {
+    public void execute_validIndexUnfilteredList_success() throws InsurancePlanException, ClaimException {
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
         Client clientToEdit = model.getFilteredClientList().get(INDEX_THIRD_CLIENT.getZeroBased());
-        InsurancePlansManager insurancePlansManager = clientToEdit.getInsurancePlansManager();
-        InsurancePlan insurancePlan = insurancePlansManager.getInsurancePlan(0);
+        InsurancePlansManager originalInsurancePlansManager = clientToEdit.getInsurancePlansManager();
+        InsurancePlan insurancePlan = originalInsurancePlansManager.getInsurancePlan(0);
 
         DeleteInsuranceCommand deleteInsuranceCommand = new DeleteInsuranceCommand(INDEX_THIRD_CLIENT, 0);
 
-        InsurancePlansManager updatedInsurancePlansManager = new InsurancePlansManager(
-                insurancePlansManager.toString());
+        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlansManager.createCopy();
         updatedInsurancePlansManager.deletePlan(insurancePlan);
 
         Client updatedClient = new Client(clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
@@ -52,7 +52,8 @@ class DeleteInsuranceCommandTest {
 
         expectedModel.setClient(clientToEdit, updatedClient);
 
-        assertCommandSuccess(deleteInsuranceCommand, model, expectedMessage, expectedModel);
+        assertInsuranceCommandSuccess(deleteInsuranceCommand, model, expectedMessage,
+                originalInsurancePlansManager, updatedInsurancePlansManager);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddInsuranceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddInsuranceCommandParserTest.java
@@ -67,13 +67,12 @@ public class AddInsuranceCommandParserTest {
     }
 
     /**
-     * Tests the execution of {@code AddInsuranceCommandParser} where PREFIX_INSURANCE_ID and insurance ID are missing.
-     * This test verifies that when PREFIX_INSURANCE_ID and insurance ID are not specified,
+     * Tests the execution of {@code AddInsuranceCommandParser} with missing PREFIX_INSURANCE_ID.
+     * This test verifies that when PREFIX_INSURANCE_ID is not specified,
      * the command throws a {@code ParseException}.
      */
     @Test
     public void parse_missingInsuranceIdPrefix_throwsParseException() {
-        // Valid client index but the PREFIX_INSURANCE_ID is completely missing
         String userInputWithoutInsuranceIdPrefix = INDEX_FIRST_CLIENT.getOneBased() + " ";
         assertParseFailure(parser, userInputWithoutInsuranceIdPrefix,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInsuranceCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/AddInsuranceCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddInsuranceCommandParserTest.java
@@ -1,0 +1,81 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE_ID;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.AddInsuranceCommand;
+
+/**
+ * Contains unit tests for {@link AddInsuranceCommandParser}.
+ */
+public class AddInsuranceCommandParserTest {
+
+    private static final int VALID_INSURANCE_ID = 0;
+    private final AddInsuranceCommandParser parser = new AddInsuranceCommandParser();
+
+    /**
+     * Tests if {@code AddInsuranceCommandParser} correctly parses valid input
+     * and returns a {@code AddInsuranceCommand}.
+     */
+    @Test
+    public void parse_validArgs_returnsAddInsuranceCommand() {
+        String validUserInput = INDEX_FIRST_CLIENT.getOneBased() + " " + PREFIX_INSURANCE_ID + VALID_INSURANCE_ID;
+        AddInsuranceCommand expectedCommand = new AddInsuranceCommand(INDEX_FIRST_CLIENT, VALID_INSURANCE_ID);
+
+        assertParseSuccess(parser, validUserInput, expectedCommand);
+    }
+
+    /**
+     * Tests the execution of {@code AddInsuranceCommandParser} with an invalid client index.
+     * This test verifies that when the specified client index is invalid,
+     * the command throws a {@code ParseException}.
+     */
+    @Test
+    public void parse_invalidIndex_throwsParseException() {
+        String invalidUserInput = "invalidIndex " + PREFIX_INSURANCE_ID + VALID_INSURANCE_ID;
+        assertParseFailure(parser, invalidUserInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInsuranceCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests the execution of {@code AddInsuranceCommandParser} with missing insurance ID.
+     * This test verifies that when insurance ID is not specified,
+     * the command throws a {@code ParseException}.
+     */
+    @Test
+    public void parse_missingInsuranceId_throwsParseException() {
+        String missingInsuranceIdInput = INDEX_FIRST_CLIENT.getOneBased() + " " + PREFIX_INSURANCE_ID;
+        assertParseFailure(parser, missingInsuranceIdInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInsuranceCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests the execution of {@code AddInsuranceCommandParser} with an invalid insurance ID.
+     * This test verifies that when the specified insurance ID is invalid,
+     * the command throws a {@code ParseException}.
+     */
+    @Test
+    public void parse_invalidInsuranceId_throwsParseException() {
+        String invalidInsuranceIdInput = INDEX_FIRST_CLIENT.getOneBased() + " " + PREFIX_INSURANCE_ID + "invalidId";
+        assertParseFailure(parser, invalidInsuranceIdInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInsuranceCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests the execution of {@code AddInsuranceCommandParser} where PREFIX_INSURANCE_ID and insurance ID are missing.
+     * This test verifies that when PREFIX_INSURANCE_ID and insurance ID are not specified,
+     * the command throws a {@code ParseException}.
+     */
+    @Test
+    public void parse_missingInsuranceIdPrefix_throwsParseException() {
+        // Valid client index but the PREFIX_INSURANCE_ID is completely missing
+        String userInputWithoutInsuranceIdPrefix = INDEX_FIRST_CLIENT.getOneBased() + " ";
+        assertParseFailure(parser, userInputWithoutInsuranceIdPrefix,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddInsuranceCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Update DeleteInsuranceCommandTest to use `assertInsuranceCommandSuccess` instead of `assertCommandSuccess` and use `createCopy` method of InsurancePlansManager.

The changes were made to match the changes done in #146 .