### PR TITLE
Add UML sequence drawings for AddClaimCommand

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveFileName = 'InSUREance.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'

--- a/docs/diagrams/add-claim/AddClaimSequenceDiagram-Logic.puml
+++ b/docs/diagrams/add-claim/AddClaimSequenceDiagram-Logic.puml
@@ -1,0 +1,52 @@
+@startuml
+!include ../style.puml
+skinparam ArrowFontStyle plain
+
+box Logic LOGIC_COLOR_T1
+participant ":LogicManager" as LogicManager LOGIC_COLOR
+participant ":AddressBookParser" as AddressBookParser LOGIC_COLOR
+participant ":u:AddClaimCommand" as AddClaimCommand LOGIC_COLOR
+end box
+
+box Model MODEL_COLOR_T1
+participant ":Model" as Model MODEL_COLOR
+end box
+[-> LogicManager : execute(addClaimCommand)
+activate LogicManager
+
+LogicManager -> AddressBookParser : parseCommand(input string)
+activate AddressBookParser
+
+create AddClaimCommand
+AddressBookParser -> AddClaimCommand
+activate AddClaimCommand
+
+AddClaimCommand --> AddressBookParser
+deactivate AddClaimCommand
+
+AddressBookParser --> LogicManager : u
+deactivate AddressBookParser
+
+LogicManager -> AddClaimCommand : execute()
+activate AddClaimCommand
+
+AddClaimCommand -> Model : createClaim(claim inputs)
+activate Model
+
+Model --> AddClaimCommand : Claim
+deactivate Model
+
+AddClaimCommand -> Model : addClaim(Claim)
+activate Model
+
+Model --> AddClaimCommand
+deactivate Model
+
+AddClaimCommand --> LogicManager : result
+deactivate AddClaimCommand
+AddClaimCommand -[hidden]-> LogicManager : result
+destroy AddClaimCommand
+
+[<--LogicManager
+deactivate LogicManager
+@enduml


### PR DESCRIPTION
This will be used for updating of developer guide and implementation explanation later on. It just creates a sequence diagram of the implementation of the add claim command in the logic section only.

Fixes #140 