### PR TITLE
Fix format issues in parseClaimAmount

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -23,8 +23,6 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_UNPARSABLE_INSURANCE_ID = "Insurance ID must be a positive integer.";
-    public static final String MESSAGE_INVALID_CENTS = "The claim amount can only contain up to 2 digits of cents.";
-    public static final String MESSAGE_TOO_MANY_DECIMALS = "Too many decimal points in claim amount!";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -161,8 +159,10 @@ public class ParserUtil {
         requireNonNull(claimAmount);
         String[] claimAmountString = claimAmount.trim().split("\\.");
 
-        if (claimAmountString.length != 2) {
-            throw new ParseException(MESSAGE_TOO_MANY_DECIMALS);
+        if (claimAmountString.length > 2) {
+            throw new ParseException(Claim.MESSAGE_TOO_MANY_DECIMALS);
+        } else if (claimAmountString.length == 1) {
+            throw new ParseException(Claim.INVALID_CLAIM_AMOUNT);
         }
 
         int claimAmountInt;
@@ -173,7 +173,7 @@ public class ParserUtil {
 
             String claimAmountCentsString = claimAmountString[1].trim();
             if (claimAmountCentsString.length() > 2) {
-                throw new ParseException(MESSAGE_INVALID_CENTS);
+                throw new ParseException(Claim.MESSAGE_INVALID_CENTS);
             }
             int claimAmountCents = Integer.parseInt(claimAmountCentsString);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -172,7 +172,7 @@ public class ParserUtil {
             int claimAmountDollars = Integer.parseInt(claimAmountString[0].trim());
 
             String claimAmountCentsString = claimAmountString[1].trim();
-            if (claimAmountCentsString.length() > 2) {
+            if (claimAmountCentsString.length() != 2) {
                 throw new ParseException(Claim.MESSAGE_INVALID_CENTS);
             }
             int claimAmountCents = Integer.parseInt(claimAmountCentsString);

--- a/src/main/java/seedu/address/model/client/insurance/claim/Claim.java
+++ b/src/main/java/seedu/address/model/client/insurance/claim/Claim.java
@@ -10,9 +10,10 @@ public class Claim {
     public static final String INVALID_CLAIM_ID = "Invalid Claim ID, must follow: "
             + "Letter + 4 digits only.";
 
-    public static final String NEGATIVE_CLAIM_AMOUNT = "Claim Amount cannot be negative";
+    public static final String NEGATIVE_CLAIM_AMOUNT = "Claim Amount cannot be negative.";
     public static final String INVALID_CLAIM_AMOUNT = "Claim about must be in dollars and cents eg. 151.00";
-    public static final String MESSAGE_INVALID_CENTS = "The claim amount can only contain up to 2 digits of cents.";
+    public static final String MESSAGE_INVALID_CENTS = "The claim amount must contain at least and "
+            + "only equal to 2 digits of cents eg. 151.00";
     public static final String MESSAGE_TOO_MANY_DECIMALS = "Too many decimal points in claim amount!";
 
     private final String claimId;

--- a/src/main/java/seedu/address/model/client/insurance/claim/Claim.java
+++ b/src/main/java/seedu/address/model/client/insurance/claim/Claim.java
@@ -11,7 +11,9 @@ public class Claim {
             + "Letter + 4 digits only.";
 
     public static final String NEGATIVE_CLAIM_AMOUNT = "Claim Amount cannot be negative";
-    public static final String INVALID_CLAIM_AMOUNT = "Claim Amount must be a positive integer";
+    public static final String INVALID_CLAIM_AMOUNT = "Claim about must be in dollars and cents eg. 151.00";
+    public static final String MESSAGE_INVALID_CENTS = "The claim amount can only contain up to 2 digits of cents.";
+    public static final String MESSAGE_TOO_MANY_DECIMALS = "Too many decimal points in claim amount!";
 
     private final String claimId;
     private boolean isOpen;


### PR DESCRIPTION
Previously, the following error was seen:

If there is no decimal point give, it (wrongly) tells you `Too many decimal points in claim amount!`

<img width="739" alt="image" src="https://github.com/user-attachments/assets/9a0ce644-2f85-46e5-8ad2-03bf3a21d0ac">

This has been fixed and now shows this:

<img width="739" alt="image" src="https://github.com/user-attachments/assets/a5b3401a-09a9-4c38-ba3e-68bb37cec42b">

Additionally, if a non-string value is entered, it parses it gracefully too:

<img width="739" alt="image" src="https://github.com/user-attachments/assets/1c90181b-03ec-4843-bcd5-e8cc3a5dd2fd">
