### PR TITLE
Add tests for CloseClaimCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
@@ -103,10 +103,4 @@ public class CloseClaimCommand extends Command {
                 && insuranceId == otherCloseClaimCommand.insuranceId
                 && claimId.equals(otherCloseClaimCommand.claimId);
     }
-
-    @Override
-    public String toString() {
-        return " " + index + insuranceId + claimId;
-    }
-
 }

--- a/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
@@ -86,4 +86,27 @@ public class CloseClaimCommand extends Command {
             throw new CommandException(String.format(e.getMessage(), insuranceId, Messages.format(clientToCloseClaim)));
         }
     }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CloseClaimCommand)) {
+            return false;
+        }
+
+        CloseClaimCommand otherCloseClaimCommand = (CloseClaimCommand) other;
+        return index.equals(otherCloseClaimCommand.index)
+                && insuranceId == otherCloseClaimCommand.insuranceId
+                && claimId.equals(otherCloseClaimCommand.claimId);
+    }
+
+    @Override
+    public String toString() {
+        return " " + index + insuranceId + claimId;
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
@@ -94,13 +94,13 @@ public class CloseClaimCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof CloseClaimCommand)) {
-            return false;
+        if (other instanceof CloseClaimCommand) {
+            CloseClaimCommand otherCloseClaimCommand = (CloseClaimCommand) other;
+            return index.equals(otherCloseClaimCommand.index)
+                    && insuranceId == otherCloseClaimCommand.insuranceId
+                    && claimId.equals(otherCloseClaimCommand.claimId);
         }
 
-        CloseClaimCommand otherCloseClaimCommand = (CloseClaimCommand) other;
-        return index.equals(otherCloseClaimCommand.index)
-                && insuranceId == otherCloseClaimCommand.insuranceId
-                && claimId.equals(otherCloseClaimCommand.claimId);
+        return false;
     }
 }

--- a/src/test/java/seedu/address/logic/parser/CloseClaimCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CloseClaimCommandParserTest.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CLAIM_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INSURANCE_ID;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CLIENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.CloseClaimCommand;
+
+public class CloseClaimCommandParserTest {
+
+    private static final int VALID_INSURANCE_ID = 0;
+    private static final String VALID_CLAIM_ID = "A1001";
+    private final CloseClaimCommandParser parser = new CloseClaimCommandParser();
+
+    /**
+     * Tests if {@code CloseClaimCommandParser} correctly parses valid input
+     * and returns a {@code CloseClaimCommand}.
+     */
+    @Test
+    public void parse_validArgs_returnsCloseClaimCommand() {
+        String userInput = INDEX_SECOND_CLIENT.getOneBased() + " "
+                + PREFIX_INSURANCE_ID + VALID_INSURANCE_ID + " "
+                + PREFIX_CLAIM_ID + VALID_CLAIM_ID;
+
+        CloseClaimCommand expectedCommand = new CloseClaimCommand(INDEX_SECOND_CLIENT, VALID_INSURANCE_ID,
+                VALID_CLAIM_ID);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    /**
+     * Tests if {@code CloseClaimCommandParser} throws a {@code ParseException}
+     * when the insurance ID is missing in the user input.
+     */
+    @Test
+    public void parse_missingInsuranceId_throwsParseException() {
+        String missingInsuranceIdInput = INDEX_SECOND_CLIENT.getOneBased() + " "
+                + PREFIX_CLAIM_ID + VALID_CLAIM_ID + " ";
+        assertParseFailure(parser, missingInsuranceIdInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CloseClaimCommand.MESSAGE_USAGE));
+    }
+
+    /**
+     * Tests if {@code CloseClaimCommandParser} throws a {@code ParseException}
+     * when the claim ID is missing in the user input.
+     */
+    @Test
+    public void parse_missingClaimId_throwsParseException() {
+        String missingClaimIdInput = INDEX_SECOND_CLIENT.getOneBased() + " "
+                + PREFIX_INSURANCE_ID + VALID_INSURANCE_ID;
+        assertParseFailure(parser, missingClaimIdInput,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CloseClaimCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Adding tests for CloseClaimCommandParser to increase our test coverage. 

While testing it was also discovered that the CloseClaimCommand was somehow missing an equals method, so that has been added in as well 😅 