### PR TITLE
Add test for AddClaimCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
@@ -84,7 +84,7 @@ public class AddClaimCommand extends Command {
             model.setClient(clientToEdit, clientWithAddedClaim);
             model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
-            return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(clientToEdit), planToBeUsed,
+            return new CommandResult(String.format(MESSAGE_SUCCESS, clientToEdit.getName().toString(), planToBeUsed,
                     claimId, Messages.formatClaimAmount(claimAmount)));
         } catch (ClaimException e) {
             throw new CommandException(String.format(e.getMessage(), claimId, Messages.format(clientToEdit)));

--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlan.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlan.java
@@ -103,13 +103,8 @@ public abstract class InsurancePlan {
             return true;
         } else if (other instanceof InsurancePlan) {
             InsurancePlan otherInsurancePlan = (InsurancePlan) other;
-            if (otherInsurancePlan.insurancePlanId != this.insurancePlanId) {
-                return false;
-            }
-            if (!otherInsurancePlan.claims.equals(this.claims)) {
-                return false;
-            }
-            return true;
+            return this.insurancePlanId == otherInsurancePlan.insurancePlanId
+                    && this.claims.equals(otherInsurancePlan.claims);
         }
         return false;
     }

--- a/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
+++ b/src/main/java/seedu/address/model/client/insurance/InsurancePlansManager.java
@@ -329,10 +329,7 @@ public class InsurancePlansManager {
             return true;
         } else if (other instanceof InsurancePlansManager) {
             InsurancePlansManager otherInsurancePlansManager = (InsurancePlansManager) other;
-            if (!otherInsurancePlansManager.insurancePlans.equals(this.insurancePlans)) {
-                return false;
-            }
-            return true;
+            return otherInsurancePlansManager.insurancePlans.equals(this.insurancePlans);
         }
         return false;
     }

--- a/src/main/java/seedu/address/model/client/insurance/claim/Claim.java
+++ b/src/main/java/seedu/address/model/client/insurance/claim/Claim.java
@@ -118,13 +118,15 @@ public class Claim {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof Claim c)) {
-            return false;
+        if (other instanceof Claim) {
+            Claim otherClaim = (Claim) other;
+
+            return this.claimId.equals(otherClaim.claimId)
+                    && this.isOpen == otherClaim.isOpen
+                    && this.claimAmount == otherClaim.claimAmount;
         }
 
-        return claimId.equals(c.getClaimId())
-                && isOpen == c.getClaimStatus()
-                && claimAmount == c.getClaimAmount();
+        return false;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddClaimCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddClaimCommandTest.java
@@ -36,11 +36,17 @@ class AddClaimCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
+    /**
+     * Tests the execution of {@code AddClaimCommand} with a valid index, valid insurance ID and valid Claim
+     * This test verifies that when a valid client index, valid insurance plan and valid Claim are provided,
+     * the valid Claim is successfully added to the specified client.
+     */
     @Test
     public void execute_validIndexUnfilteredList_success() throws
             InsurancePlanException, ClaimException {
         ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
+        // Using Benny, who has basic insurance plan and travel insurance plan but no claims
         Client clientToEdit = model.getFilteredClientList().get(INDEX_SECOND_CLIENT.getZeroBased());
         InsurancePlansManager originalInsurancePlansManager = clientToEdit.getInsurancePlansManager();
         InsurancePlan insurancePlan = originalInsurancePlansManager.getInsurancePlan(VALID_INSURANCE_ID_FIRST);
@@ -67,6 +73,11 @@ class AddClaimCommandTest {
                 clientToEdit.getInsurancePlansManager(), updatedInsurancePlansManager);
     }
 
+    /**
+     * Tests the execution of {@code AddClaimCommand} with a valid index, valid insurance ID and valid Claim
+     * that the client already has. This test verifies that when a duplicate claim is provided,
+     * a {@code CommandException} will be thrown.
+     */
     @Test
     public void execute_duplicateClaim_throwsCommandException() {
         // Carl is the client used for testing, and already has plan
@@ -81,6 +92,11 @@ class AddClaimCommandTest {
         assertThrows(CommandException.class, () -> failingAddClaimCommand.execute(model));
     }
 
+    /**
+     * Tests the execution of {@code AddClaimCommand} with a valid index, valid insurance ID and
+     * invalid Claim (invalid Claim amount). This test verifies that when an invalid claim is provided,
+     * a {@code CommandException} will be thrown.
+     */
     @Test
     public void execute_invalidClaimAmount_throwsCommandException() {
         AddClaimCommand failingAddClaimCommand =
@@ -90,6 +106,11 @@ class AddClaimCommandTest {
         assertThrows(CommandException.class, () -> failingAddClaimCommand.execute(model));
     }
 
+    /**
+     * Tests the execution of {@code AddClaimCommand} with a valid index, invalid insurance ID and
+     * valid Claim. This test verifies that when an invalid insurance ID is provided,
+     * a {@code CommandException} will be thrown.
+     */
     @Test
     public void execute_invalidInsurancePlan_throwsCommandException() {
         InsurancePlan fakeInsurancePlan = new InvalidInsurancePlan();
@@ -102,6 +123,9 @@ class AddClaimCommandTest {
         assertThrows(CommandException.class, () -> failingAddClaimCommand.execute(model));
     }
 
+    /**
+     * Tests the {@code equals} method to determine that it produces the right output
+     */
     @Test
     public void equals() {
         AddClaimCommand addClaimFirstCommand =

--- a/src/test/java/seedu/address/logic/commands/AddClaimCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddClaimCommandTest.java
@@ -1,0 +1,139 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertInsuranceCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalClients.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_CLIENT;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CLIENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.client.Client;
+import seedu.address.model.client.exceptions.ClaimException;
+import seedu.address.model.client.exceptions.InsurancePlanException;
+import seedu.address.model.client.insurance.InsurancePlan;
+import seedu.address.model.client.insurance.InsurancePlansManager;
+import seedu.address.model.client.insurance.InvalidInsurancePlan;
+import seedu.address.model.client.insurance.claim.Claim;
+
+class AddClaimCommandTest {
+
+    public static final int VALID_INSURANCE_ID_FIRST = 0;
+    public static final int VALID_INSURANCE_ID_SECOND = 1;
+    public static final String VALID_CLAIM_ID_FIRST = "A1001";
+    public static final String VALID_CLAIM_ID_SECOND = "B1234";
+    public static final int VALID_CLAIM_AMOUNT_FIRST = 10000;
+    public static final int VALID_CLAIM_AMOUNT_SECOND = 20000;
+    public static final int INVALID_CLAIM_AMOUNT = -1;
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() throws
+            InsurancePlanException, ClaimException {
+        ModelManager expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        Client clientToEdit = model.getFilteredClientList().get(INDEX_SECOND_CLIENT.getZeroBased());
+        InsurancePlansManager originalInsurancePlansManager = clientToEdit.getInsurancePlansManager();
+        InsurancePlan insurancePlan = originalInsurancePlansManager.getInsurancePlan(VALID_INSURANCE_ID_FIRST);
+
+        // rebuilds a copy of the claims from string to prevent same-object manipulation
+        Claim claim = new Claim(VALID_CLAIM_ID_FIRST, VALID_CLAIM_AMOUNT_FIRST);
+        InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlansManager.createCopy();
+        updatedInsurancePlansManager.addClaimToInsurancePlan(insurancePlan, claim);
+
+        AddClaimCommand addClaimCommand =
+                new AddClaimCommand(INDEX_SECOND_CLIENT, VALID_INSURANCE_ID_FIRST,
+                        claim.getClaimId(), claim.getClaimAmount());
+
+        String expectedMessage = String.format(AddClaimCommand.MESSAGE_SUCCESS,
+                clientToEdit.getName().toString(), insurancePlan, claim.getClaimId(),
+                Messages.formatClaimAmount(claim.getClaimAmount()));
+
+        Client updatedClient = new Client(clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
+                clientToEdit.getAddress(), updatedInsurancePlansManager, clientToEdit.getTags());
+
+        expectedModel.setClient(clientToEdit, updatedClient);
+
+        assertInsuranceCommandSuccess(addClaimCommand, model, expectedMessage,
+                clientToEdit.getInsurancePlansManager(), updatedInsurancePlansManager);
+    }
+
+    @Test
+    public void execute_duplicateClaim_throwsCommandException() {
+        // Carl is the client used for testing, and already has plan
+        // "A1001" with claim amount 10000
+        String carlClaimId = "A1001";
+        int carlClaimAmount = 10000;
+
+        AddClaimCommand failingAddClaimCommand =
+                new AddClaimCommand(INDEX_THIRD_CLIENT, 0,
+                        carlClaimId, carlClaimAmount);
+
+        assertThrows(CommandException.class, () -> failingAddClaimCommand.execute(model));
+    }
+
+    @Test
+    public void execute_invalidClaimAmount_throwsCommandException() {
+        AddClaimCommand failingAddClaimCommand =
+                new AddClaimCommand(INDEX_THIRD_CLIENT, 0,
+                        VALID_CLAIM_ID_FIRST, INVALID_CLAIM_AMOUNT);
+
+        assertThrows(CommandException.class, () -> failingAddClaimCommand.execute(model));
+    }
+
+    @Test
+    public void execute_invalidInsurancePlan_throwsCommandException() {
+        InsurancePlan fakeInsurancePlan = new InvalidInsurancePlan();
+
+        Claim validClaim = new Claim(VALID_CLAIM_ID_FIRST, VALID_CLAIM_AMOUNT_FIRST);
+        AddClaimCommand failingAddClaimCommand = new AddClaimCommand(INDEX_THIRD_CLIENT,
+                fakeInsurancePlan.getInsurancePlanId(), validClaim.getClaimId(),
+                validClaim.getClaimAmount());
+
+        assertThrows(CommandException.class, () -> failingAddClaimCommand.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        AddClaimCommand addClaimFirstCommand =
+                new AddClaimCommand(INDEX_SECOND_CLIENT, VALID_INSURANCE_ID_FIRST,
+                        VALID_CLAIM_ID_FIRST, VALID_CLAIM_AMOUNT_FIRST);
+        AddClaimCommand addClaimSecondCommand =
+                new AddClaimCommand(INDEX_SECOND_CLIENT, VALID_INSURANCE_ID_SECOND,
+                        VALID_CLAIM_ID_SECOND, VALID_CLAIM_AMOUNT_FIRST);
+        AddClaimCommand addClaimThirdCommand =
+                new AddClaimCommand(INDEX_SECOND_CLIENT, VALID_INSURANCE_ID_SECOND,
+                        VALID_CLAIM_ID_SECOND, VALID_CLAIM_AMOUNT_SECOND);
+
+        // same object -> returns true
+        assertEquals(addClaimFirstCommand, addClaimFirstCommand);
+
+        // same values -> returns true
+        AddClaimCommand addClaimFirstCommandCopy =
+                new AddClaimCommand(INDEX_SECOND_CLIENT, VALID_INSURANCE_ID_FIRST,
+                        VALID_CLAIM_ID_FIRST, VALID_CLAIM_AMOUNT_FIRST);
+        assertEquals(addClaimFirstCommand, addClaimFirstCommandCopy);
+
+        // different types -> returns false
+        assertNotEquals(1, addClaimFirstCommand);
+
+        // null -> returns false
+        assertNotEquals(null, addClaimFirstCommand);
+
+        // different insurance/claim id -> returns false
+        assertNotEquals(addClaimFirstCommand, addClaimSecondCommand);
+
+        // same claim id, different claim amount -> returns false
+        assertNotEquals(addClaimSecondCommand, addClaimThirdCommand);
+    }
+}
+


### PR DESCRIPTION
Adding tests for `AddClaimCommand` to increase our testing coverage.

In the `AddClaimCommand`, I also noticed that we were printing out the full details of the `client` (including their `address`, `phone number` and so on) every time we add a claim. Assuming this is not intentional, I changed it to show only the name which is in line with other commands such as `DeleteClaimCommand`. But if this was intentional I am happy to change it back 👍 

**Note to reviewer**: I also refactored some of the equals methods that were found to be (slightly) messy while writing the tests (and digging around to see if it was the cause of my failing tests (spoiler: it was `not`)), so just help me to check that 1. the original logic is still there 2. I didn't cause anything else to break, thanks 🙂 