### PR TITLE
Rezwan update feedback messages

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -57,9 +57,6 @@ InSUREance is a **desktop app for managing contacts, optimized for use via a  Li
 * Items with `…`​ after them can be used multiple times including zero times.<br>
   e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
 
-* Parameters can be in any order.<br>
-  e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
-
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
@@ -108,7 +105,7 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 * When editing tags, the existing tags of the client will be removed i.e adding of tags is not cumulative.
 * You can remove all the client’s tags by typing `t/` without
     specifying any tags after it.
-* Insurance plans and claims cannot be modified directly using this command. You may use other features such as `addInsurance`, `deleteInsurance`, `closeClaim` to make any necessary updates.
+* Insurance plans and claims cannot be modified directly using this command. You may use other features such as `addInsurance`, `deleteInsurance`, `addClaim`, `deleteClaim` and `closeClaim` to make any necessary updates.
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st client to be `91234567` and `johndoe@example.com` respectively.
@@ -209,7 +206,7 @@ IDs for insurance plans:
 same ID here to delete the claim.
 
 * If the `CLIENT_ID` is invalid, or the client does not have the insurance plan `INSURANCE_ID`, the
-  user will be informed with an error message.
+  user will be informed with an appropriate error message.
 
 Examples:
 * `deleteClaim 1 iid/1 cid/B1234` deletes the claim of CLAIM_ID B1234 from a client at INDEX 1 which is tagged

--- a/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddClaimCommand.java
@@ -84,12 +84,12 @@ public class AddClaimCommand extends Command {
             model.setClient(clientToEdit, clientWithAddedClaim);
             model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
-            return new CommandResult(String.format(MESSAGE_SUCCESS, clientToEdit.getName().toString(), planToBeUsed,
-                    claimId, Messages.formatClaimAmount(claimAmount)));
+            return new CommandResult(String.format(MESSAGE_SUCCESS, clientWithAddedClaim.getName().toString(),
+                    planToBeUsed, claimId, Messages.formatClaimAmount(claimAmount)));
         } catch (ClaimException e) {
-            throw new CommandException(String.format(e.getMessage(), claimId, Messages.format(clientToEdit)));
+            throw new CommandException(String.format(e.getMessage(), claimId, clientToEdit.getName().toString()));
         } catch (InsurancePlanException e) {
-            throw new CommandException(String.format(e.getMessage(), insuranceId, Messages.format(clientToEdit)));
+            throw new CommandException(String.format(e.getMessage(), insuranceId, clientToEdit.getName().toString()));
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddInsuranceCommand.java
@@ -71,10 +71,10 @@ public class AddInsuranceCommand extends Command {
             model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
             return new CommandResult(String.format(MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
-                    planToBeAdded, Messages.format(clientWithAddedInsurancePlan)));
+                    planToBeAdded, clientWithAddedInsurancePlan.getName().toString()));
         } catch (InsurancePlanException e) {
             throw new CommandException(
-                    String.format(e.getMessage(), insuranceId, Messages.format(clientToEdit)));
+                    String.format(e.getMessage(), insuranceId, clientToEdit.getName().toString()));
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CloseClaimCommand.java
@@ -64,10 +64,10 @@ public class CloseClaimCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
         }
 
-        Client clientToCloseClaim = lastShownList.get(index.getZeroBased());
+        Client clientToEdit = lastShownList.get(index.getZeroBased());
 
         try {
-            InsurancePlansManager clientToEditInsurancePlansManager = clientToCloseClaim.getInsurancePlansManager();
+            InsurancePlansManager clientToEditInsurancePlansManager = clientToEdit.getInsurancePlansManager();
             InsurancePlan planToBeUsed = clientToEditInsurancePlansManager.getInsurancePlan(insuranceId);
             clientToEditInsurancePlansManager.checkIfPlanOwned(planToBeUsed);
 
@@ -75,15 +75,15 @@ public class CloseClaimCommand extends Command {
             clientToEditInsurancePlansManager.closeClaim(planToBeUsed, claimToBeMarkedAsClosed);
 
             Client clientWithClosedClaim = lastShownList.get(index.getZeroBased());
-            model.setClient(clientToCloseClaim, clientWithClosedClaim);
+            model.setClient(clientToEdit, clientWithClosedClaim);
             model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
-            return new CommandResult(String.format(MESSAGE_CLOSE_CLAIM_SUCCESS, clientToCloseClaim.getName().toString(),
-                    planToBeUsed, claimId));
+            return new CommandResult(String.format(MESSAGE_CLOSE_CLAIM_SUCCESS,
+                    clientWithClosedClaim.getName().toString(), planToBeUsed, claimId));
         } catch (ClaimException e) {
-            throw new CommandException(String.format(e.getMessage(), claimId, Messages.format(clientToCloseClaim)));
+            throw new CommandException(String.format(e.getMessage(), claimId, clientToEdit.getName().toString()));
         } catch (InsurancePlanException e) {
-            throw new CommandException(String.format(e.getMessage(), insuranceId, Messages.format(clientToCloseClaim)));
+            throw new CommandException(String.format(e.getMessage(), insuranceId, clientToEdit.getName().toString()));
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteClaimCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteClaimCommand.java
@@ -79,12 +79,12 @@ public class DeleteClaimCommand extends Command {
             model.setClient(clientToEdit, clientWithDeletedClaim);
             model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
-            return new CommandResult(String.format(MESSAGE_DELETE_CLAIM_SUCCESS, clientToEdit.getName().toString(),
-                    planToBeUsed, claimId));
+            return new CommandResult(String.format(MESSAGE_DELETE_CLAIM_SUCCESS,
+                    clientWithDeletedClaim.getName().toString(), planToBeUsed, claimId));
         } catch (ClaimException e) {
-            throw new CommandException(String.format(e.getMessage(), claimId, Messages.format(clientToEdit)));
+            throw new CommandException(String.format(e.getMessage(), claimId, clientToEdit.getName().toString()));
         } catch (InsurancePlanException e) {
-            throw new CommandException(String.format(e.getMessage(), insuranceId, Messages.format(clientToEdit)));
+            throw new CommandException(String.format(e.getMessage(), insuranceId, clientToEdit.getName().toString()));
         }
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteInsuranceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteInsuranceCommand.java
@@ -70,10 +70,10 @@ public class DeleteInsuranceCommand extends Command {
             model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
 
             return new CommandResult(String.format(MESSAGE_DELETE_INSURANCE_PLAN_SUCCESS,
-                    planToBeDeleted, Messages.format(clientWithDeletedInsurancePlan)));
+                    planToBeDeleted, clientWithDeletedInsurancePlan.getName().toString()));
         } catch (InsurancePlanException e) {
             throw new CommandException(
-                    String.format(e.getMessage(), insuranceID, Messages.format(clientToEdit)));
+                    String.format(e.getMessage(), insuranceID, clientToEdit.getName().toString()));
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddInsuranceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddInsuranceCommandTest.java
@@ -53,7 +53,7 @@ class AddInsuranceCommandTest {
         AddInsuranceCommand addInsuranceCommand = new AddInsuranceCommand(INDEX_FOURTH_CLIENT, validInsuranceId);
 
         String expectedMessage = String.format(AddInsuranceCommand.MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
-                planToBeAdded, Messages.format(updatedClient));
+                planToBeAdded, updatedClient.getName().toString());
 
         InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlansManager.createCopy();
         updatedInsurancePlansManager.addPlan(planToBeAdded);
@@ -84,7 +84,7 @@ class AddInsuranceCommandTest {
                 .build();
 
         String firstExpectedMessage = String.format(AddInsuranceCommand.MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
-                firstPlan, Messages.format(clientWithFirstPlan));
+                firstPlan, clientWithFirstPlan.getName().toString());
 
         InsurancePlansManager updatedInsurancePlansManager = originalInsurancePlansManager.createCopy();
         updatedInsurancePlansManager.addPlan(firstPlan);
@@ -103,7 +103,7 @@ class AddInsuranceCommandTest {
                 .build();
 
         String secondExpectedMessage = String.format(AddInsuranceCommand.MESSAGE_ADD_INSURANCE_PLAN_SUCCESS,
-                secondPlan, Messages.format(clientWithBothPlans));
+                secondPlan, clientWithBothPlans.getName().toString());
 
         updatedInsurancePlansManager.addPlan(secondPlan);
 
@@ -139,7 +139,7 @@ class AddInsuranceCommandTest {
 
         assertCommandFailure(addInsuranceCommand, model,
                 String.format(DUPLICATE_PLAN_DETECTED_MESSAGE,
-                        basicInsuranceId, Messages.format(BENSON)));
+                        basicInsuranceId, BENSON.getName().toString()));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteInsuranceCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteInsuranceCommandTest.java
@@ -10,7 +10,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_CLIENT;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
@@ -48,7 +47,7 @@ class DeleteInsuranceCommandTest {
         Client updatedClient = new Client(clientToEdit.getName(), clientToEdit.getPhone(), clientToEdit.getEmail(),
                 clientToEdit.getAddress(), updatedInsurancePlansManager, clientToEdit.getTags());
         String expectedMessage = String.format(DeleteInsuranceCommand.MESSAGE_DELETE_INSURANCE_PLAN_SUCCESS,
-                insurancePlan, Messages.format(updatedClient));
+                insurancePlan, updatedClient.getName().toString());
 
         expectedModel.setClient(clientToEdit, updatedClient);
 


### PR DESCRIPTION
The feedback message is long winded and provides irrelevant info
to the user.

This makes the app more difficult to use as the user has to read
through alot of information to understand if their command was
successful or not.

The following command feedback messages were updated in a consistent
manner:

1. AddClaimCommand
2. AddInsuranceCommand
3. CloseClaimCommand
4. DeleteClaimCommand
5. DeleteInsuranceCommand

fix #192 
fix #179 