### PR TITLE
Update save data section in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -337,8 +337,11 @@ App data are saved automatically as a JSON file `[JAR file location]/data/addres
 <box type="warning" seamless>
 
 **Caution:**
-If your changes to the data file makes its format invalid, app will discard all data and start with an empty data file at the next run.  Hence, it is recommended to take a backup of the file before editing it.<br>
-Furthermore, certain edits can cause the app to behave in unexpected ways (e.g., if a value entered is outside the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+If your changes to the data file makes its format invalid, app will discard all data at the start of the next run. <br>
+A new data file with sample data will replace the corrupted file once a new successful command is executed.
+Hence, it is recommended to take a backup of the file before editing it.<br>
+Furthermore, certain edits can cause the app to behave in unexpected ways (e.g., if a value entered is outside the acceptable range).
+Therefore, edit the data file only if you are confident that you can update it correctly.
 </box>
 
 --------------------------------------------------------------------------------------------------------------------
@@ -346,7 +349,8 @@ Furthermore, certain edits can cause the app to behave in unexpected ways (e.g.,
 ## FAQ
 
 **Q**: How do I transfer my data to another Computer?<br>
-**A**: Install the app in the other computer and overwrite the empty data file it creates with the file that contains the data of your previous app home folder.
+**A**: Install the app in the other computer and overwrite the initial data file it generates with the file that contains
+the data of your previous app home folder.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -338,7 +338,7 @@ App data are saved automatically as a JSON file `[JAR file location]/data/addres
 
 **Caution:**
 If your changes to the data file makes its format invalid, app will discard all data at the start of the next run. <br>
-An empty data file will replace the corrupted file once a new successful command is executed.
+A new data file without previously saved data will replace the corrupted file once a new successful command is executed.
 Hence, it is recommended to take a backup of the file before editing it.<br>
 Furthermore, certain edits can cause the app to behave in unexpected ways (e.g., if a value entered is outside the acceptable range).
 Therefore, edit the data file only if you are confident that you can update it correctly.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -338,7 +338,7 @@ App data are saved automatically as a JSON file `[JAR file location]/data/addres
 
 **Caution:**
 If your changes to the data file makes its format invalid, app will discard all data at the start of the next run. <br>
-A new data file with sample data will replace the corrupted file once a new successful command is executed.
+An empty data file will replace the corrupted file once a new successful command is executed.
 Hence, it is recommended to take a backup of the file before editing it.<br>
 Furthermore, certain edits can cause the app to behave in unexpected ways (e.g., if a value entered is outside the acceptable range).
 Therefore, edit the data file only if you are confident that you can update it correctly.


### PR DESCRIPTION
The save data warning section is currently not consistent with the behaviour observed in the warning section of the UG with regards to corrupt data.

Let's update the UG to make it more consistent and not confuse users.

Fixes #268 .